### PR TITLE
Prefix user error message with error type

### DIFF
--- a/api/v1alpha2/resource_error.go
+++ b/api/v1alpha2/resource_error.go
@@ -174,6 +174,10 @@ func (e *ResourceErrorInfo) Error() string {
 	return fmt.Sprintf("%s error: %s", strings.ToLower(string(e.Type)), message)
 }
 
+func (e *ResourceErrorInfo) GetUserMessage() string {
+	return fmt.Sprintf("%s error: %s", string(e.Type), e.UserMessage)
+}
+
 func (e *ResourceError) SetResourceErrorAndLog(err error, log logr.Logger) {
 	e.SetResourceError(err)
 	if err == nil {


### PR DESCRIPTION
Add a receiver function for resource errors that prefixes the user message with the type of error that it is: Internal, WLM, or User.