### PR TITLE
Dynamically create an overlay for the image tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,5 @@ kind-*.yaml
 nnf-sos
 mount-daemon/clientmount
 .version
+config/begin/*
 

--- a/Makefile
+++ b/Makefile
@@ -163,8 +163,8 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 
 deploy: VERSION ?= $(shell cat .version)
 deploy: .version kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMAGE_TAG_BASE):$(VERSION)
-	$(KUSTOMIZE) build config/${OVERLAY} | kubectl apply -f -
+	$(KUSTOMIZE_IMAGE_TAG) config/begin $(OVERLAY) $(IMAGE_TAG_BASE) $(VERSION)
+	$(KUSTOMIZE) build config/begin | kubectl apply -f -
 
 undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/${OVERLAY} | kubectl delete --ignore-not-found -f -
@@ -190,6 +190,7 @@ clean-bin:
 	fi
 
 ## Tool Binaries
+KUSTOMIZE_IMAGE_TAG ?= ./hack/make-kustomization.sh
 GO_INSTALL := ./github/cluster-api/scripts/go_install.sh
 KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -18,4 +18,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/dataworkflowservices/dws
-  newTag: c781b2ec850b09e06a6974e58e1f9a69b05d1760
+  newTag: latest

--- a/hack/make-kustomization.sh
+++ b/hack/make-kustomization.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Copyright 2023 Hewlett Packard Enterprise Development LP
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+OVERLAY_DIR=$1
+OVERLAY=$2
+IMAGE_TAG_BASE=$3
+TAG=$4
+
+if [[ ! -d $OVERLAY_DIR ]]
+then
+    mkdir "$OVERLAY_DIR"
+fi
+
+cat <<EOF > "$OVERLAY_DIR"/kustomization.yaml
+resources:
+- ../$OVERLAY
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: $IMAGE_TAG_BASE
+  newTag: $TAG
+EOF
+


### PR DESCRIPTION
Avoid editing config/manager/kustomization.yaml to set the image tag.  This causes git to consider the workarea to be dirty, so two consecutive deploys from a workarea that has no other changes will result in the second deploy looking for an image with a "-dirty" tag.

Instead, from the makefile we create a throw-away, and untracked, overlay that will be used to set the image tag.