### PR TITLE
Requirements for Prometheus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,10 +164,10 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 deploy: VERSION ?= $(shell cat .version)
 deploy: .version kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE_IMAGE_TAG) config/begin $(OVERLAY) $(IMAGE_TAG_BASE) $(VERSION)
-	$(KUSTOMIZE) build config/begin | kubectl apply -f -
+	./deploy.sh deploy $(KUSTOMIZE) config/begin
 
 undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/${OVERLAY} | kubectl delete --ignore-not-found -f -
+	./deploy.sh undeploy $(KUSTOMIZE) config/$(OVERLAY)
 
 # Let .version be phony so that a git update to the workarea can be reflected
 # in it each time it's needed.

--- a/config/prometheus/kustomization.yaml
+++ b/config/prometheus/kustomization.yaml
@@ -1,2 +1,5 @@
+# Adds namespace to all resources.
+namespace: dws-system
+
 resources:
 - monitor.yaml

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -5,6 +5,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     control-plane: controller-manager
+    prometheus-app: rabbit-nnf
   name: controller-manager-metrics-monitor
   namespace: system
 spec:

--- a/config/rbac/auth_proxy_client_clusterrole_binding.yaml
+++ b/config/rbac/auth_proxy_client_clusterrole_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: metrics-reader-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metrics-reader
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: system

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -22,6 +22,7 @@ resources:
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
 - auth_proxy_client_clusterrole.yaml
+- auth_proxy_client_clusterrole_binding.yaml
 
 configurations:
   - kustomizeconfig.yaml

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Copyright 2023 Hewlett Packard Enterprise Development LP
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# Deploy/undeploy controller to the K8s cluster specified in ~/.kube/config.
+
+CMD=$1
+KUSTOMIZE=$2
+OVERLAY_DIR=$3
+
+if [[ $CMD == 'deploy' ]]; then
+    $KUSTOMIZE build config/begin | kubectl apply -f -
+
+    # Deploy the ServiceMonitor resource if its CRD is found. The CRD would
+    # have been installed by a metrics service such as Prometheus.
+    if kubectl get crd servicemonitors.monitoring.coreos.com > /dev/null 2>&1; then
+        $KUSTOMIZE build config/prometheus | kubectl apply -f-
+    fi
+fi
+
+if [[ $CMD == 'undeploy' ]]; then
+    $KUSTOMIZE build config/prometheus | kubectl delete --ignore-not-found -f-
+    $KUSTOMIZE build $OVERLAY_DIR | kubectl delete --ignore-not-found -f -
+fi
+
+exit 0


### PR DESCRIPTION
Add a label to the ServiceMonitor resource that will be common across all DWS and NNF repos so we easily tell Prometheus which ones it should select.

Copy the namespace value into config/prometheus so that part of config/ can be deployed on its own.

Add a ClusterRoleBinding that can be used by a metrics reader process to debug the metrics endpoing of the controller.  The ClusterRole is already being installed, and the ServiceAccount is already installed.

Introduce a deploy.sh script for the "make deploy" and "make undeploy" targets. This script will do the usuall deploy/undeploy, but will also determine whether or not the ServiceMonitor resource can be applied.