### PR TITLE
Support multi architecture building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@
 FROM golang:1.19 as builder
 
 ARG TARGETARCH
+ARG TARGETOS
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -35,7 +36,7 @@ COPY vendor/ vendor/
 COPY github/cluster-api/util/conversion/ github/cluster-api/util/conversion/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
 
 FROM builder as testing
 WORKDIR /workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@
 # Build the manager binary
 FROM golang:1.19 as builder
 
+ARG TARGETARCH
+
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
@@ -33,7 +35,7 @@ COPY vendor/ vendor/
 COPY github/cluster-api/util/conversion/ github/cluster-api/util/conversion/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager cmd/main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
 
 FROM builder as testing
 WORKDIR /workspace


### PR DESCRIPTION
I'm running through the example at https://github.com/DataWorkflowServices/dws-slurm-bb-plugin?tab=readme-ov-file#the-integration-test-environment-as-a-playground with the latest versions of everything and am making PRs based on changes I found I need for proper building on arm.

Using TARGETARCH in the dockerfile should retain functionality for amd64 and allow for building on other archs. It also opens up the possibility for multi arch images.