### PR TITLE
Limit the SystemConfiguration CRD conversion

### DIFF
--- a/api/v1alpha1/conversion.go
+++ b/api/v1alpha1/conversion.go
@@ -398,7 +398,7 @@ func (dst *SystemConfiguration) ConvertFrom(srcRaw conversion.Hub) error {
 	dst.Spec.ComputeNodes = computes
 
 	// Preserve Hub data on down-conversion except for metadata.
-	return utilconversion.MarshalData(src, dst)
+	return nil // utilconversion.MarshalData(src, dst)
 }
 
 func (src *Workflow) ConvertTo(dstRaw conversion.Hub) error {

--- a/api/v1alpha1/conversion_test.go
+++ b/api/v1alpha1/conversion_test.go
@@ -24,7 +24,8 @@ import (
 
 	fuzz "github.com/google/gofuzz"
 	. "github.com/onsi/ginkgo/v2"
-	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
+
+	//"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 
 	dwsv1alpha2 "github.com/DataWorkflowServices/dws/api/v1alpha2"
@@ -68,11 +69,11 @@ func TestFuzzyConversion(t *testing.T) {
 		Spoke: &Storage{},
 	}))
 
-	t.Run("for SystemConfiguration", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
-		Hub:         &dwsv1alpha2.SystemConfiguration{},
-		Spoke:       &SystemConfiguration{},
-		FuzzerFuncs: []fuzzer.FuzzerFuncs{SystemConfigurationFuzzFunc},
-	}))
+	//t.Run("for SystemConfiguration", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
+	//	Hub:         &dwsv1alpha2.SystemConfiguration{},
+	//	Spoke:       &SystemConfiguration{},
+	//	FuzzerFuncs: []fuzzer.FuzzerFuncs{SystemConfigurationFuzzFunc},
+	//}))
 
 	t.Run("for Workflow", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
 		Hub:   &dwsv1alpha2.Workflow{},

--- a/internal/controller/conversion_test.go
+++ b/internal/controller/conversion_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Hewlett Packard Enterprise Development LP
+ * Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,
@@ -365,14 +365,14 @@ var _ = Describe("Conversion Webhook Test", func() {
 		})
 
 		It("reads SystemConfiguration resource via hub and via spoke", func() {
-			// Spoke should have annotation.
-			resSpoke := &dwsv1alpha1.SystemConfiguration{}
-			Eventually(func(g Gomega) {
-				g.Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(resHub), resSpoke)).To(Succeed())
-				anno := resSpoke.GetAnnotations()
-				g.Expect(anno).To(HaveLen(1))
-				g.Expect(anno).Should(HaveKey(utilconversion.DataAnnotation))
-			}).Should(Succeed())
+			//// Spoke should have annotation.
+			//resSpoke := &dwsv1alpha1.SystemConfiguration{}
+			//Eventually(func(g Gomega) {
+			//	g.Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(resHub), resSpoke)).To(Succeed())
+			//	anno := resSpoke.GetAnnotations()
+			//	g.Expect(anno).To(HaveLen(1))
+			//	g.Expect(anno).Should(HaveKey(utilconversion.DataAnnotation))
+			//}).Should(Succeed())
 
 			// Hub should not have annotation.
 			Eventually(func(g Gomega) {


### PR DESCRIPTION
When converting to the v1alpha1 spoke do not add the annotation that is the serialized version of the v1alpha2 hub. On a customer site that annotation is too big for the k8s limit of 262144 bytes.

With this change, we can still convert v1alpha2->v1alpha1 and v1alpha1->v1alph2, but we can't convert v1alpha1->v1alpha2->v1alpha1 and v1alpha2->v1alpha1->v1alpha2. However those last two (1-2-1 and 2-1-2) happen only in the conversion test suite, and that is disabled now.