### PR TITLE
Fix ResourceError kubebuilder validation

### DIFF
--- a/api/v1alpha2/resource_error.go
+++ b/api/v1alpha2/resource_error.go
@@ -63,7 +63,7 @@ type ResourceErrorInfo struct {
 	DebugMessage string `json:"debugMessage"`
 
 	// Internal or user error
-	// +kubebuilder:validation:Enum=Internal;User
+	// +kubebuilder:validation:Enum=Internal;User;WLM
 	Type ResourceErrorType `json:"type"`
 
 	// Indication of how severe the error is. Minor will likely succeed, Major may

--- a/config/crd/bases/dataworkflowservices.github.io_clientmounts.yaml
+++ b/config/crd/bases/dataworkflowservices.github.io_clientmounts.yaml
@@ -532,6 +532,7 @@ spec:
                     enum:
                     - Internal
                     - User
+                    - WLM
                     type: string
                   userMessage:
                     description: Optional user facing message if the error is relevant

--- a/config/crd/bases/dataworkflowservices.github.io_directivebreakdowns.yaml
+++ b/config/crd/bases/dataworkflowservices.github.io_directivebreakdowns.yaml
@@ -486,6 +486,7 @@ spec:
                     enum:
                     - Internal
                     - User
+                    - WLM
                     type: string
                   userMessage:
                     description: Optional user facing message if the error is relevant

--- a/config/crd/bases/dataworkflowservices.github.io_persistentstorageinstances.yaml
+++ b/config/crd/bases/dataworkflowservices.github.io_persistentstorageinstances.yaml
@@ -373,6 +373,7 @@ spec:
                     enum:
                     - Internal
                     - User
+                    - WLM
                     type: string
                   userMessage:
                     description: Optional user facing message if the error is relevant

--- a/config/crd/bases/dataworkflowservices.github.io_servers.yaml
+++ b/config/crd/bases/dataworkflowservices.github.io_servers.yaml
@@ -268,6 +268,7 @@ spec:
                     enum:
                     - Internal
                     - User
+                    - WLM
                     type: string
                   userMessage:
                     description: Optional user facing message if the error is relevant


### PR DESCRIPTION
The ResourceErrorType field was missing the "WLM" type in the kubebuilder validation.