### PR TITLE
Add version labels to release manifest items

### DIFF
--- a/hack/make-kustomization.sh
+++ b/hack/make-kustomization.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2023 Hewlett Packard Enterprise Development LP
+# Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 # Other additional copyright holders may be indicated within.
 #
 # The entirety of this work is licensed under the Apache License,
@@ -32,6 +32,21 @@ fi
 cat <<EOF > "$OVERLAY_DIR"/kustomization.yaml
 resources:
 - ../$OVERLAY
+
+commonLabels:
+  app.kubernetes.io/version: "$TAG"
+  app.kubernetes.io/component: dws
+EOF
+
+if [[ -n $NNF_VERSION ]]
+then
+    cat <<EOF >> "$OVERLAY_DIR"/kustomization.yaml
+  app.kubernetes.io/nnf-version: "$NNF_VERSION"
+  app.kubernetes.io/part-of: nnf
+EOF
+fi
+
+cat <<EOF >> "$OVERLAY_DIR"/kustomization.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization


### PR DESCRIPTION
Add component/version labels to each resource in the manifest. If run locally the labels will be:

  app.kubernetes.io/component: dws
  app.kubernetes.io/version: <git-version-gen>

If run from nnf-deploy's "make manifests" the labels will be:

  app.kubernetes.io/component: dws
  app.kubernetes.io/version: <dws's git-version-gen>
  app.kubernetes.io/part-of: nnf
  app.kubernetes.io/nnf-version: <nnf-deploy's git-version-gen>