### PR TITLE
Add UID/GID to workflow `-o wide` output

### DIFF
--- a/api/v1alpha2/workflow_types.go
+++ b/api/v1alpha2/workflow_types.go
@@ -259,6 +259,8 @@ type WorkflowStatus struct {
 //+kubebuilder:printcolumn:name="DESIREDSTATE",type="string",JSONPath=".spec.desiredState",description="Desired state",priority=1
 //+kubebuilder:printcolumn:name="DESIREDSTATECHANGE",type="date",JSONPath=".status.desiredStateChange",description="Time of most recent desiredState change",priority=1
 //+kubebuilder:printcolumn:name="ELAPSEDTIMELASTSTATE",type="string",JSONPath=".status.elapsedTimeLastState",description="Duration of last state change",priority=1
+//+kubebuilder:printcolumn:name="UID",type="string",JSONPath=".spec.userID",description="UID",priority=1
+//+kubebuilder:printcolumn:name="GID",type="string",JSONPath=".spec.groupID",description="GID",priority=1
 
 // Workflow is the Schema for the workflows API
 type Workflow struct {

--- a/config/crd/bases/dataworkflowservices.github.io_workflows.yaml
+++ b/config/crd/bases/dataworkflowservices.github.io_workflows.yaml
@@ -395,6 +395,16 @@ spec:
       name: ELAPSEDTIMELASTSTATE
       priority: 1
       type: string
+    - description: UID
+      jsonPath: .spec.userID
+      name: UID
+      priority: 1
+      type: string
+    - description: GID
+      jsonPath: .spec.groupID
+      name: GID
+      priority: 1
+      type: string
     name: v1alpha2
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
Examples:

```
$ kubectl get workflows
NAME                         STATE   READY   STATUS       JOBID         AGE
fluxjob-201564367429304320   Setup   false   DriverWait   fU8ws95yjjM   15s
fluxjob-201564367362195456   Setup   false   DriverWait   fU8ws8z3nby   15s

$ kubectl get workflows -o wide
NAME                         STATE   READY   STATUS       JOBID         AGE   DESIREDSTATE   DESIREDSTATECHANGE   ELAPSEDTIMELASTSTATE   UID    GID
fluxjob-201564367429304320   Setup   false   DriverWait   fU8ws95yjjM   18s   Setup          13s                  50.577ms               1060   100
fluxjob-201564367362195456   Setup   false   DriverWait   fU8ws8z3nby   18s   Setup          13s                  51.308ms               1060   100
```

Signed-off-by: Blake Devcich <blake.devcich@hpe.com>
