### PR TITLE
Add comment markers for the crd-bumper tool

### DIFF
--- a/github/cluster-api/util/conversion/conversion_test.go
+++ b/github/cluster-api/util/conversion/conversion_test.go
@@ -35,12 +35,14 @@ var (
 		Version: "v1old",
 		Kind:    "Workflow",
 	}
+
+	// +crdbumper:scaffold:gvk
 )
 
 func TestMarshalData(t *testing.T) {
 	g := NewWithT(t)
 
-	t.Run("should write source object to destination", func(*testing.T) {
+	t.Run("Workflow should write source object to destination", func(*testing.T) {
 		src := &dwsv1alpha2.Workflow{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test-1",
@@ -73,7 +75,7 @@ func TestMarshalData(t *testing.T) {
 		g.Expect(dst.GetAnnotations()[DataAnnotation]).ToNot(ContainSubstring("label1"))
 	})
 
-	t.Run("should append the annotation", func(*testing.T) {
+	t.Run("Workflow should append the annotation", func(*testing.T) {
 		src := &dwsv1alpha2.Workflow{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test-1",
@@ -89,12 +91,14 @@ func TestMarshalData(t *testing.T) {
 		g.Expect(MarshalData(src, dst)).To(Succeed())
 		g.Expect(dst.GetAnnotations()).To(HaveLen(2))
 	})
+
+	// +crdbumper:scaffold:marshaldata
 }
 
 func TestUnmarshalData(t *testing.T) {
 	g := NewWithT(t)
 
-	t.Run("should return false without errors if annotation doesn't exist", func(*testing.T) {
+	t.Run("Workflow should return false without errors if annotation doesn't exist", func(*testing.T) {
 		src := &dwsv1alpha2.Workflow{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test-1",
@@ -109,7 +113,7 @@ func TestUnmarshalData(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 	})
 
-	t.Run("should return true when a valid annotation with data exists", func(*testing.T) {
+	t.Run("Workflow should return true when a valid annotation with data exists", func(*testing.T) {
 		src := &unstructured.Unstructured{}
 		src.SetGroupVersionKind(oldWorkflowGVK)
 		src.SetName("test-1")
@@ -133,7 +137,7 @@ func TestUnmarshalData(t *testing.T) {
 		g.Expect(dst.GetAnnotations()).To(BeEmpty())
 	})
 
-	t.Run("should clean the annotation on successful unmarshal", func(*testing.T) {
+	t.Run("Workflow should clean the annotation on successful unmarshal", func(*testing.T) {
 		src := &unstructured.Unstructured{}
 		src.SetGroupVersionKind(oldWorkflowGVK)
 		src.SetName("test-1")
@@ -155,6 +159,8 @@ func TestUnmarshalData(t *testing.T) {
 		g.Expect(src.GetAnnotations()).ToNot(HaveKey(DataAnnotation))
 		g.Expect(src.GetAnnotations()).To(HaveLen(1))
 	})
+
+	// +crdbumper:scaffold:unmarshaldata
 }
 
 // Just touch ginkgo, so it's here to interpret any ginkgo args from

--- a/internal/controller/conversion_test.go
+++ b/internal/controller/conversion_test.go
@@ -106,7 +106,7 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}).Should(Succeed())
 		})
 
-		// +crdbumper:scaffold:spoketest="dws.ClientMount"
+		// +crdbumper:scaffold:spoketest="dataworkflowservices.ClientMount"
 	})
 
 	Context("DWDirectiveRule", func() {
@@ -153,7 +153,7 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}).Should(Succeed())
 		})
 
-		// +crdbumper:scaffold:spoketest="dws.DWDirectiveRule"
+		// +crdbumper:scaffold:spoketest="dataworkflowservices.DWDirectiveRule"
 	})
 
 	Context("DirectiveBreakdown", func() {
@@ -200,7 +200,7 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}).Should(Succeed())
 		})
 
-		// +crdbumper:scaffold:spoketest="dws.DirectiveBreakdown"
+		// +crdbumper:scaffold:spoketest="dataworkflowservices.DirectiveBreakdown"
 	})
 
 	Context("PersistentStorageInstance", func() {
@@ -253,7 +253,7 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}).Should(Succeed())
 		})
 
-		// +crdbumper:scaffold:spoketest="dws.PersistentStorageInstance"
+		// +crdbumper:scaffold:spoketest="dataworkflowservices.PersistentStorageInstance"
 	})
 
 	Context("Servers", func() {
@@ -300,7 +300,7 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}).Should(Succeed())
 		})
 
-		// +crdbumper:scaffold:spoketest="dws.Servers"
+		// +crdbumper:scaffold:spoketest="dataworkflowservices.Servers"
 	})
 
 	Context("Storage", func() {
@@ -347,7 +347,7 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}).Should(Succeed())
 		})
 
-		// +crdbumper:scaffold:spoketest="dws.Storage"
+		// +crdbumper:scaffold:spoketest="dataworkflowservices.Storage"
 	})
 
 	Context("SystemConfiguration", func() {
@@ -394,7 +394,7 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}).Should(Succeed())
 		})
 
-		// +crdbumper:scaffold:spoketest="dws.SystemConfiguration"
+		// +crdbumper:scaffold:spoketest="dataworkflowservices.SystemConfiguration"
 	})
 
 	Context("Workflow", func() {
@@ -472,7 +472,7 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}).Should(Succeed())
 		})
 
-		// +crdbumper:scaffold:spoketest="dws.Workflow"
+		// +crdbumper:scaffold:spoketest="dataworkflowservices.Workflow"
 	})
 
 	// +crdbumper:scaffold:webhooksuitetest

--- a/internal/controller/conversion_test.go
+++ b/internal/controller/conversion_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}
 		})
 
-		It("reads ClientMount resource via hub and via spoke", func() {
+		It("reads ClientMount resource via hub and via spoke v1alpha1", func() {
 			// Spoke should have annotation.
 			resSpoke := &dwsv1alpha1.ClientMount{}
 			Eventually(func(g Gomega) {
@@ -105,6 +105,8 @@ var _ = Describe("Conversion Webhook Test", func() {
 				g.Expect(anno).To(HaveLen(0))
 			}).Should(Succeed())
 		})
+
+		// +crdbumper:scaffold:spoketest="dws.ClientMount"
 	})
 
 	Context("DWDirectiveRule", func() {
@@ -133,7 +135,7 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}
 		})
 
-		It("reads DWDirectiveRule resource via hub and via spoke", func() {
+		It("reads DWDirectiveRule resource via hub and via spoke v1alpha1", func() {
 			// Spoke should have annotation.
 			resSpoke := &dwsv1alpha1.DWDirectiveRule{}
 			Eventually(func(g Gomega) {
@@ -150,6 +152,8 @@ var _ = Describe("Conversion Webhook Test", func() {
 				g.Expect(anno).To(HaveLen(0))
 			}).Should(Succeed())
 		})
+
+		// +crdbumper:scaffold:spoketest="dws.DWDirectiveRule"
 	})
 
 	Context("DirectiveBreakdown", func() {
@@ -178,7 +182,7 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}
 		})
 
-		It("reads DirectiveBreakdown resource via hub and via spoke", func() {
+		It("reads DirectiveBreakdown resource via hub and via spoke v1alpha1", func() {
 			// Spoke should have annotation.
 			resSpoke := &dwsv1alpha1.DirectiveBreakdown{}
 			Eventually(func(g Gomega) {
@@ -195,6 +199,8 @@ var _ = Describe("Conversion Webhook Test", func() {
 				g.Expect(anno).To(HaveLen(0))
 			}).Should(Succeed())
 		})
+
+		// +crdbumper:scaffold:spoketest="dws.DirectiveBreakdown"
 	})
 
 	Context("PersistentStorageInstance", func() {
@@ -229,7 +235,7 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}
 		})
 
-		It("reads PersistentStorageInstance resource via hub and via spoke", func() {
+		It("reads PersistentStorageInstance resource via hub and via spoke v1alpha1", func() {
 			// Spoke should have annotation.
 			resSpoke := &dwsv1alpha1.PersistentStorageInstance{}
 			Eventually(func(g Gomega) {
@@ -246,6 +252,8 @@ var _ = Describe("Conversion Webhook Test", func() {
 				g.Expect(anno).To(HaveLen(0))
 			}).Should(Succeed())
 		})
+
+		// +crdbumper:scaffold:spoketest="dws.PersistentStorageInstance"
 	})
 
 	Context("Servers", func() {
@@ -274,7 +282,7 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}
 		})
 
-		It("reads Servers resource via hub and via spoke", func() {
+		It("reads Servers resource via hub and via spoke v1alpha1", func() {
 			// Spoke should have annotation.
 			resSpoke := &dwsv1alpha1.Servers{}
 			Eventually(func(g Gomega) {
@@ -291,6 +299,8 @@ var _ = Describe("Conversion Webhook Test", func() {
 				g.Expect(anno).To(HaveLen(0))
 			}).Should(Succeed())
 		})
+
+		// +crdbumper:scaffold:spoketest="dws.Servers"
 	})
 
 	Context("Storage", func() {
@@ -319,7 +329,7 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}
 		})
 
-		It("reads Storage resource via hub and via spoke", func() {
+		It("reads Storage resource via hub and via spoke v1alpha1", func() {
 			// Spoke should have annotation.
 			resSpoke := &dwsv1alpha1.Storage{}
 			Eventually(func(g Gomega) {
@@ -336,6 +346,8 @@ var _ = Describe("Conversion Webhook Test", func() {
 				g.Expect(anno).To(HaveLen(0))
 			}).Should(Succeed())
 		})
+
+		// +crdbumper:scaffold:spoketest="dws.Storage"
 	})
 
 	Context("SystemConfiguration", func() {
@@ -364,7 +376,7 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}
 		})
 
-		It("reads SystemConfiguration resource via hub and via spoke", func() {
+		It("reads SystemConfiguration resource via hub and via spoke v1alpha1", func() {
 			//// Spoke should have annotation.
 			//resSpoke := &dwsv1alpha1.SystemConfiguration{}
 			//Eventually(func(g Gomega) {
@@ -381,6 +393,8 @@ var _ = Describe("Conversion Webhook Test", func() {
 				g.Expect(anno).To(HaveLen(0))
 			}).Should(Succeed())
 		})
+
+		// +crdbumper:scaffold:spoketest="dws.SystemConfiguration"
 	})
 
 	Context("Workflow", func() {
@@ -418,7 +432,7 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}
 		})
 
-		It("reads Workflow resource via hub and via spoke", func() {
+		It("reads Workflow resource via hub and via spoke v1alpha1", func() {
 			// Spoke should have annotation.
 			resSpoke := &dwsv1alpha1.Workflow{}
 			Eventually(func(g Gomega) {
@@ -436,7 +450,7 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}).Should(Succeed())
 		})
 
-		It("reads Computes resource via hub and via spoke", func() {
+		It("reads Computes resource via hub and via spoke v1alpha1", func() {
 			// The workflow_controller's Reconcile() created
 			// a Computes resource to match the Workflow resource.
 
@@ -457,5 +471,9 @@ var _ = Describe("Conversion Webhook Test", func() {
 				g.Expect(anno).To(HaveLen(0))
 			}).Should(Succeed())
 		})
+
+		// +crdbumper:scaffold:spoketest="dws.Workflow"
 	})
+
+	// +crdbumper:scaffold:webhooksuitetest
 })

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021-2023.
+Copyright 2021-2024.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -145,6 +145,8 @@ var _ = BeforeSuite(func() {
 
 	err = (&dwsv1alpha2.Workflow{}).SetupWebhookWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
+
+	// +crdbumper:scaffold:builder
 
 	// start reconcilers
 


### PR DESCRIPTION
This tool uses "marker comments" in the Go code to indicate where generated code should be placed.  These markers are used the same way `controller-gen` uses code markers.