### PR TITLE
Squash the warnings about patchesStrategicMerge

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -24,20 +24,25 @@ resources:
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
-patchesStrategicMerge:
+patches:
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
-- manager_auth_proxy_patch.yaml
+- path: manager_auth_proxy_patch.yaml
 
 # Mount the controller config file for loading manager configurations
 # through a ComponentConfig type
-#- manager_config_patch.yaml
+#- path: manager_config_patch.yaml
+
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
+# crd/kustomization.yaml
+- path: manager_webhook_patch.yaml
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection
-- webhookcainjection_patch.yaml
+- path: webhookcainjection_mutating_patch.yaml
+- path: webhookcainjection_validating_patch.yaml
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
 # Uncomment the following replacements to add the cert-manager CA injection annotations

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -1,23 +1,27 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: controller-manager
   namespace: system
-spec:
-  template:
-    spec:
-      containers:
-      - name: manager
-        ports:
-        - containerPort: 9443
-          name: webhook-server
-          protocol: TCP
-        volumeMounts:
-        - mountPath: /tmp/k8s-webhook-server/serving-certs
-          name: cert
-          readOnly: true
-      volumes:
-      - name: cert
-        secret:
-          defaultMode: 420
-          secretName: webhook-server-cert
+
+# NOTE: this version of the patch is not used. We have it in a different patch.
+
+#spec:
+#  template:
+#    spec:
+#      containers:
+#      - name: manager
+#        ports:
+#        - containerPort: 9443
+#          name: webhook-server
+#          protocol: TCP
+#        volumeMounts:
+#        - mountPath: /tmp/k8s-webhook-server/serving-certs
+#          name: cert
+#          readOnly: true
+#      volumes:
+#      - name: cert
+#        secret:
+#          defaultMode: 420
+#          secretName: webhook-server-cert

--- a/config/default/webhookcainjection_mutating_patch.yaml
+++ b/config/default/webhookcainjection_mutating_patch.yaml
@@ -6,10 +6,3 @@ metadata:
   name: mutating-webhook-configuration
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
----
-apiVersion: admissionregistration.k8s.io/v1
-kind: ValidatingWebhookConfiguration
-metadata:
-  name: validating-webhook-configuration
-  annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)

--- a/config/default/webhookcainjection_validating_patch.yaml
+++ b/config/default/webhookcainjection_validating_patch.yaml
@@ -1,0 +1,8 @@
+# This patch add annotation to admission webhook config and
+# the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -10,8 +10,9 @@ configMapGenerator:
   - controller_manager_config.yaml
   name: manager-config
 
-#patchesStrategicMerge:
-#- manager_imagepullsecret_patch.yaml
+#patches:
+#- path: manager_imagepullsecret_controller_patch.yaml
+#- path: manager_imagepullsecret_webhook_patch.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/config/manager/manager_imagepullsecret_controller_patch.yaml
+++ b/config/manager/manager_imagepullsecret_controller_patch.yaml
@@ -8,14 +8,3 @@ spec:
     spec:
       imagePullSecrets:
       - name: name_of_secret
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: webhook
-  namespace: system
-spec:
-  template:
-    spec:
-      imagePullSecrets:
-      - name: name_of_secret

--- a/config/manager/manager_imagepullsecret_webhook_patch.yaml
+++ b/config/manager/manager_imagepullsecret_webhook_patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: webhook
+  namespace: system
+spec:
+  template:
+    spec:
+      imagePullSecrets:
+      - name: name_of_secret


### PR DESCRIPTION
Add a stub for manager_webhook_patch.yaml so newer versions of
"kubebuilder create webhook" can be satisfied when they're looking for it.
