### PR TITLE
Switch dws webhook to a cluster IP

### DIFF
--- a/api/v1alpha3/workflow_webhook.go
+++ b/api/v1alpha3/workflow_webhook.go
@@ -82,6 +82,7 @@ var _ webhook.Validator = &Workflow{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (w *Workflow) ValidateCreate() (admission.Warnings, error) {
+	workflowlog.Info("validate-create", "name", w.Name)
 
 	specPath := field.NewPath("Spec")
 
@@ -101,6 +102,7 @@ func (w *Workflow) ValidateCreate() (admission.Warnings, error) {
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (w *Workflow) ValidateUpdate(old runtime.Object) (admission.Warnings, error) {
+	// workflowlog.Info("validate-update", "name", w.Name)  // Too chatty.
 
 	oldWorkflow, ok := old.(*Workflow)
 	if !ok {

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -10,4 +10,3 @@ spec:
       targetPort: 9443
   selector:
     control-plane: webhook
-  type: LoadBalancer


### PR DESCRIPTION
Use a ClusterIP for the dws webhhook.

The LoadBalancer would be used only if things outside the cluster needed to get to the webhook, and we don't have that case.