### PR TITLE
Add forceReady field to Workflow resource

### DIFF
--- a/api/v1alpha1/zz_generated.conversion.go
+++ b/api/v1alpha1/zz_generated.conversion.go
@@ -423,11 +423,6 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*v1alpha5.ServersStatusStorage)(nil), (*ServersStatusStorage)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1alpha5_ServersStatusStorage_To_v1alpha1_ServersStatusStorage(a.(*v1alpha5.ServersStatusStorage), b.(*ServersStatusStorage), scope)
-	}); err != nil {
-		return err
-	}
 	if err := s.AddGeneratedConversionFunc((*Storage)(nil), (*v1alpha5.Storage)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1alpha1_Storage_To_v1alpha5_Storage(a.(*Storage), b.(*v1alpha5.Storage), scope)
 	}); err != nil {
@@ -610,6 +605,11 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}
 	if err := s.AddConversionFunc((*v1alpha5.ResourceErrorInfo)(nil), (*ResourceErrorInfo)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1alpha5_ResourceErrorInfo_To_v1alpha1_ResourceErrorInfo(a.(*v1alpha5.ResourceErrorInfo), b.(*ResourceErrorInfo), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddConversionFunc((*v1alpha5.ServersStatusStorage)(nil), (*ServersStatusStorage)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1alpha5_ServersStatusStorage_To_v1alpha1_ServersStatusStorage(a.(*v1alpha5.ServersStatusStorage), b.(*ServersStatusStorage), scope)
 	}); err != nil {
 		return err
 	}
@@ -1662,7 +1662,17 @@ func Convert_v1alpha5_ServersSpecStorage_To_v1alpha1_ServersSpecStorage(in *v1al
 func autoConvert_v1alpha1_ServersStatus_To_v1alpha5_ServersStatus(in *ServersStatus, out *v1alpha5.ServersStatus, s conversion.Scope) error {
 	out.Ready = in.Ready
 	out.LastUpdate = (*metav1.MicroTime)(unsafe.Pointer(in.LastUpdate))
-	out.AllocationSets = *(*[]v1alpha5.ServersStatusAllocationSet)(unsafe.Pointer(&in.AllocationSets))
+	if in.AllocationSets != nil {
+		in, out := &in.AllocationSets, &out.AllocationSets
+		*out = make([]v1alpha5.ServersStatusAllocationSet, len(*in))
+		for i := range *in {
+			if err := Convert_v1alpha1_ServersStatusAllocationSet_To_v1alpha5_ServersStatusAllocationSet(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.AllocationSets = nil
+	}
 	return nil
 }
 
@@ -1674,14 +1684,36 @@ func Convert_v1alpha1_ServersStatus_To_v1alpha5_ServersStatus(in *ServersStatus,
 func autoConvert_v1alpha5_ServersStatus_To_v1alpha1_ServersStatus(in *v1alpha5.ServersStatus, out *ServersStatus, s conversion.Scope) error {
 	out.Ready = in.Ready
 	out.LastUpdate = (*metav1.MicroTime)(unsafe.Pointer(in.LastUpdate))
-	out.AllocationSets = *(*[]ServersStatusAllocationSet)(unsafe.Pointer(&in.AllocationSets))
+	if in.AllocationSets != nil {
+		in, out := &in.AllocationSets, &out.AllocationSets
+		*out = make([]ServersStatusAllocationSet, len(*in))
+		for i := range *in {
+			if err := Convert_v1alpha5_ServersStatusAllocationSet_To_v1alpha1_ServersStatusAllocationSet(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.AllocationSets = nil
+	}
 	// WARNING: in.ResourceError requires manual conversion: does not exist in peer-type
 	return nil
 }
 
 func autoConvert_v1alpha1_ServersStatusAllocationSet_To_v1alpha5_ServersStatusAllocationSet(in *ServersStatusAllocationSet, out *v1alpha5.ServersStatusAllocationSet, s conversion.Scope) error {
 	out.Label = in.Label
-	out.Storage = *(*map[string]v1alpha5.ServersStatusStorage)(unsafe.Pointer(&in.Storage))
+	if in.Storage != nil {
+		in, out := &in.Storage, &out.Storage
+		*out = make(map[string]v1alpha5.ServersStatusStorage, len(*in))
+		for key, val := range *in {
+			newVal := new(v1alpha5.ServersStatusStorage)
+			if err := Convert_v1alpha1_ServersStatusStorage_To_v1alpha5_ServersStatusStorage(&val, newVal, s); err != nil {
+				return err
+			}
+			(*out)[key] = *newVal
+		}
+	} else {
+		out.Storage = nil
+	}
 	return nil
 }
 
@@ -1692,7 +1724,19 @@ func Convert_v1alpha1_ServersStatusAllocationSet_To_v1alpha5_ServersStatusAlloca
 
 func autoConvert_v1alpha5_ServersStatusAllocationSet_To_v1alpha1_ServersStatusAllocationSet(in *v1alpha5.ServersStatusAllocationSet, out *ServersStatusAllocationSet, s conversion.Scope) error {
 	out.Label = in.Label
-	out.Storage = *(*map[string]ServersStatusStorage)(unsafe.Pointer(&in.Storage))
+	if in.Storage != nil {
+		in, out := &in.Storage, &out.Storage
+		*out = make(map[string]ServersStatusStorage, len(*in))
+		for key, val := range *in {
+			newVal := new(ServersStatusStorage)
+			if err := Convert_v1alpha5_ServersStatusStorage_To_v1alpha1_ServersStatusStorage(&val, newVal, s); err != nil {
+				return err
+			}
+			(*out)[key] = *newVal
+		}
+	} else {
+		out.Storage = nil
+	}
 	return nil
 }
 
@@ -1713,12 +1757,8 @@ func Convert_v1alpha1_ServersStatusStorage_To_v1alpha5_ServersStatusStorage(in *
 
 func autoConvert_v1alpha5_ServersStatusStorage_To_v1alpha1_ServersStatusStorage(in *v1alpha5.ServersStatusStorage, out *ServersStatusStorage, s conversion.Scope) error {
 	out.AllocationSize = in.AllocationSize
+	// WARNING: in.Ready requires manual conversion: does not exist in peer-type
 	return nil
-}
-
-// Convert_v1alpha5_ServersStatusStorage_To_v1alpha1_ServersStatusStorage is an autogenerated conversion function.
-func Convert_v1alpha5_ServersStatusStorage_To_v1alpha1_ServersStatusStorage(in *v1alpha5.ServersStatusStorage, out *ServersStatusStorage, s conversion.Scope) error {
-	return autoConvert_v1alpha5_ServersStatusStorage_To_v1alpha1_ServersStatusStorage(in, out, s)
 }
 
 func autoConvert_v1alpha1_Storage_To_v1alpha5_Storage(in *Storage, out *v1alpha5.Storage, s conversion.Scope) error {
@@ -2238,6 +2278,7 @@ func autoConvert_v1alpha5_WorkflowSpec_To_v1alpha1_WorkflowSpec(in *v1alpha5.Wor
 	out.UserID = in.UserID
 	out.GroupID = in.GroupID
 	out.Hurry = in.Hurry
+	// WARNING: in.ForceReady requires manual conversion: does not exist in peer-type
 	out.DWDirectives = *(*[]string)(unsafe.Pointer(&in.DWDirectives))
 	return nil
 }

--- a/api/v1alpha2/zz_generated.conversion.go
+++ b/api/v1alpha2/zz_generated.conversion.go
@@ -438,11 +438,6 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*v1alpha5.ServersStatusStorage)(nil), (*ServersStatusStorage)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1alpha5_ServersStatusStorage_To_v1alpha2_ServersStatusStorage(a.(*v1alpha5.ServersStatusStorage), b.(*ServersStatusStorage), scope)
-	}); err != nil {
-		return err
-	}
 	if err := s.AddGeneratedConversionFunc((*Storage)(nil), (*v1alpha5.Storage)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1alpha2_Storage_To_v1alpha5_Storage(a.(*Storage), b.(*v1alpha5.Storage), scope)
 	}); err != nil {
@@ -628,11 +623,6 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*v1alpha5.WorkflowSpec)(nil), (*WorkflowSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1alpha5_WorkflowSpec_To_v1alpha2_WorkflowSpec(a.(*v1alpha5.WorkflowSpec), b.(*WorkflowSpec), scope)
-	}); err != nil {
-		return err
-	}
 	if err := s.AddGeneratedConversionFunc((*WorkflowStatus)(nil), (*v1alpha5.WorkflowStatus)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1alpha2_WorkflowStatus_To_v1alpha5_WorkflowStatus(a.(*WorkflowStatus), b.(*v1alpha5.WorkflowStatus), scope)
 	}); err != nil {
@@ -645,6 +635,16 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}
 	if err := s.AddConversionFunc((*v1alpha5.DirectiveBreakdownStatus)(nil), (*DirectiveBreakdownStatus)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1alpha5_DirectiveBreakdownStatus_To_v1alpha2_DirectiveBreakdownStatus(a.(*v1alpha5.DirectiveBreakdownStatus), b.(*DirectiveBreakdownStatus), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddConversionFunc((*v1alpha5.ServersStatusStorage)(nil), (*ServersStatusStorage)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1alpha5_ServersStatusStorage_To_v1alpha2_ServersStatusStorage(a.(*v1alpha5.ServersStatusStorage), b.(*ServersStatusStorage), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddConversionFunc((*v1alpha5.WorkflowSpec)(nil), (*WorkflowSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1alpha5_WorkflowSpec_To_v1alpha2_WorkflowSpec(a.(*v1alpha5.WorkflowSpec), b.(*WorkflowSpec), scope)
 	}); err != nil {
 		return err
 	}
@@ -1520,7 +1520,17 @@ func Convert_v1alpha5_Servers_To_v1alpha2_Servers(in *v1alpha5.Servers, out *Ser
 
 func autoConvert_v1alpha2_ServersList_To_v1alpha5_ServersList(in *ServersList, out *v1alpha5.ServersList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]v1alpha5.Servers)(unsafe.Pointer(&in.Items))
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]v1alpha5.Servers, len(*in))
+		for i := range *in {
+			if err := Convert_v1alpha2_Servers_To_v1alpha5_Servers(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
 	return nil
 }
 
@@ -1531,7 +1541,17 @@ func Convert_v1alpha2_ServersList_To_v1alpha5_ServersList(in *ServersList, out *
 
 func autoConvert_v1alpha5_ServersList_To_v1alpha2_ServersList(in *v1alpha5.ServersList, out *ServersList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]Servers)(unsafe.Pointer(&in.Items))
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]Servers, len(*in))
+		for i := range *in {
+			if err := Convert_v1alpha5_Servers_To_v1alpha2_Servers(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
 	return nil
 }
 
@@ -1609,7 +1629,17 @@ func Convert_v1alpha5_ServersSpecStorage_To_v1alpha2_ServersSpecStorage(in *v1al
 func autoConvert_v1alpha2_ServersStatus_To_v1alpha5_ServersStatus(in *ServersStatus, out *v1alpha5.ServersStatus, s conversion.Scope) error {
 	out.Ready = in.Ready
 	out.LastUpdate = (*metav1.MicroTime)(unsafe.Pointer(in.LastUpdate))
-	out.AllocationSets = *(*[]v1alpha5.ServersStatusAllocationSet)(unsafe.Pointer(&in.AllocationSets))
+	if in.AllocationSets != nil {
+		in, out := &in.AllocationSets, &out.AllocationSets
+		*out = make([]v1alpha5.ServersStatusAllocationSet, len(*in))
+		for i := range *in {
+			if err := Convert_v1alpha2_ServersStatusAllocationSet_To_v1alpha5_ServersStatusAllocationSet(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.AllocationSets = nil
+	}
 	if err := Convert_v1alpha2_ResourceError_To_v1alpha5_ResourceError(&in.ResourceError, &out.ResourceError, s); err != nil {
 		return err
 	}
@@ -1624,7 +1654,17 @@ func Convert_v1alpha2_ServersStatus_To_v1alpha5_ServersStatus(in *ServersStatus,
 func autoConvert_v1alpha5_ServersStatus_To_v1alpha2_ServersStatus(in *v1alpha5.ServersStatus, out *ServersStatus, s conversion.Scope) error {
 	out.Ready = in.Ready
 	out.LastUpdate = (*metav1.MicroTime)(unsafe.Pointer(in.LastUpdate))
-	out.AllocationSets = *(*[]ServersStatusAllocationSet)(unsafe.Pointer(&in.AllocationSets))
+	if in.AllocationSets != nil {
+		in, out := &in.AllocationSets, &out.AllocationSets
+		*out = make([]ServersStatusAllocationSet, len(*in))
+		for i := range *in {
+			if err := Convert_v1alpha5_ServersStatusAllocationSet_To_v1alpha2_ServersStatusAllocationSet(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.AllocationSets = nil
+	}
 	if err := Convert_v1alpha5_ResourceError_To_v1alpha2_ResourceError(&in.ResourceError, &out.ResourceError, s); err != nil {
 		return err
 	}
@@ -1638,7 +1678,19 @@ func Convert_v1alpha5_ServersStatus_To_v1alpha2_ServersStatus(in *v1alpha5.Serve
 
 func autoConvert_v1alpha2_ServersStatusAllocationSet_To_v1alpha5_ServersStatusAllocationSet(in *ServersStatusAllocationSet, out *v1alpha5.ServersStatusAllocationSet, s conversion.Scope) error {
 	out.Label = in.Label
-	out.Storage = *(*map[string]v1alpha5.ServersStatusStorage)(unsafe.Pointer(&in.Storage))
+	if in.Storage != nil {
+		in, out := &in.Storage, &out.Storage
+		*out = make(map[string]v1alpha5.ServersStatusStorage, len(*in))
+		for key, val := range *in {
+			newVal := new(v1alpha5.ServersStatusStorage)
+			if err := Convert_v1alpha2_ServersStatusStorage_To_v1alpha5_ServersStatusStorage(&val, newVal, s); err != nil {
+				return err
+			}
+			(*out)[key] = *newVal
+		}
+	} else {
+		out.Storage = nil
+	}
 	return nil
 }
 
@@ -1649,7 +1701,19 @@ func Convert_v1alpha2_ServersStatusAllocationSet_To_v1alpha5_ServersStatusAlloca
 
 func autoConvert_v1alpha5_ServersStatusAllocationSet_To_v1alpha2_ServersStatusAllocationSet(in *v1alpha5.ServersStatusAllocationSet, out *ServersStatusAllocationSet, s conversion.Scope) error {
 	out.Label = in.Label
-	out.Storage = *(*map[string]ServersStatusStorage)(unsafe.Pointer(&in.Storage))
+	if in.Storage != nil {
+		in, out := &in.Storage, &out.Storage
+		*out = make(map[string]ServersStatusStorage, len(*in))
+		for key, val := range *in {
+			newVal := new(ServersStatusStorage)
+			if err := Convert_v1alpha5_ServersStatusStorage_To_v1alpha2_ServersStatusStorage(&val, newVal, s); err != nil {
+				return err
+			}
+			(*out)[key] = *newVal
+		}
+	} else {
+		out.Storage = nil
+	}
 	return nil
 }
 
@@ -1670,12 +1734,8 @@ func Convert_v1alpha2_ServersStatusStorage_To_v1alpha5_ServersStatusStorage(in *
 
 func autoConvert_v1alpha5_ServersStatusStorage_To_v1alpha2_ServersStatusStorage(in *v1alpha5.ServersStatusStorage, out *ServersStatusStorage, s conversion.Scope) error {
 	out.AllocationSize = in.AllocationSize
+	// WARNING: in.Ready requires manual conversion: does not exist in peer-type
 	return nil
-}
-
-// Convert_v1alpha5_ServersStatusStorage_To_v1alpha2_ServersStatusStorage is an autogenerated conversion function.
-func Convert_v1alpha5_ServersStatusStorage_To_v1alpha2_ServersStatusStorage(in *v1alpha5.ServersStatusStorage, out *ServersStatusStorage, s conversion.Scope) error {
-	return autoConvert_v1alpha5_ServersStatusStorage_To_v1alpha2_ServersStatusStorage(in, out, s)
 }
 
 func autoConvert_v1alpha2_Storage_To_v1alpha5_Storage(in *Storage, out *v1alpha5.Storage, s conversion.Scope) error {
@@ -2207,13 +2267,9 @@ func autoConvert_v1alpha5_WorkflowSpec_To_v1alpha2_WorkflowSpec(in *v1alpha5.Wor
 	out.UserID = in.UserID
 	out.GroupID = in.GroupID
 	out.Hurry = in.Hurry
+	// WARNING: in.ForceReady requires manual conversion: does not exist in peer-type
 	out.DWDirectives = *(*[]string)(unsafe.Pointer(&in.DWDirectives))
 	return nil
-}
-
-// Convert_v1alpha5_WorkflowSpec_To_v1alpha2_WorkflowSpec is an autogenerated conversion function.
-func Convert_v1alpha5_WorkflowSpec_To_v1alpha2_WorkflowSpec(in *v1alpha5.WorkflowSpec, out *WorkflowSpec, s conversion.Scope) error {
-	return autoConvert_v1alpha5_WorkflowSpec_To_v1alpha2_WorkflowSpec(in, out, s)
 }
 
 func autoConvert_v1alpha2_WorkflowStatus_To_v1alpha5_WorkflowStatus(in *WorkflowStatus, out *v1alpha5.WorkflowStatus, s conversion.Scope) error {

--- a/api/v1alpha3/zz_generated.conversion.go
+++ b/api/v1alpha3/zz_generated.conversion.go
@@ -448,11 +448,6 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*v1alpha5.ServersStatusStorage)(nil), (*ServersStatusStorage)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1alpha5_ServersStatusStorage_To_v1alpha3_ServersStatusStorage(a.(*v1alpha5.ServersStatusStorage), b.(*ServersStatusStorage), scope)
-	}); err != nil {
-		return err
-	}
 	if err := s.AddGeneratedConversionFunc((*Storage)(nil), (*v1alpha5.Storage)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1alpha3_Storage_To_v1alpha5_Storage(a.(*Storage), b.(*v1alpha5.Storage), scope)
 	}); err != nil {
@@ -638,11 +633,6 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*v1alpha5.WorkflowSpec)(nil), (*WorkflowSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1alpha5_WorkflowSpec_To_v1alpha3_WorkflowSpec(a.(*v1alpha5.WorkflowSpec), b.(*WorkflowSpec), scope)
-	}); err != nil {
-		return err
-	}
 	if err := s.AddGeneratedConversionFunc((*WorkflowStatus)(nil), (*v1alpha5.WorkflowStatus)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1alpha3_WorkflowStatus_To_v1alpha5_WorkflowStatus(a.(*WorkflowStatus), b.(*v1alpha5.WorkflowStatus), scope)
 	}); err != nil {
@@ -660,6 +650,16 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}
 	if err := s.AddGeneratedConversionFunc((*v1alpha5.WorkflowTokenSecret)(nil), (*WorkflowTokenSecret)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1alpha5_WorkflowTokenSecret_To_v1alpha3_WorkflowTokenSecret(a.(*v1alpha5.WorkflowTokenSecret), b.(*WorkflowTokenSecret), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddConversionFunc((*v1alpha5.ServersStatusStorage)(nil), (*ServersStatusStorage)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1alpha5_ServersStatusStorage_To_v1alpha3_ServersStatusStorage(a.(*v1alpha5.ServersStatusStorage), b.(*ServersStatusStorage), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddConversionFunc((*v1alpha5.WorkflowSpec)(nil), (*WorkflowSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1alpha5_WorkflowSpec_To_v1alpha3_WorkflowSpec(a.(*v1alpha5.WorkflowSpec), b.(*WorkflowSpec), scope)
 	}); err != nil {
 		return err
 	}
@@ -1520,7 +1520,17 @@ func Convert_v1alpha5_Servers_To_v1alpha3_Servers(in *v1alpha5.Servers, out *Ser
 
 func autoConvert_v1alpha3_ServersList_To_v1alpha5_ServersList(in *ServersList, out *v1alpha5.ServersList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]v1alpha5.Servers)(unsafe.Pointer(&in.Items))
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]v1alpha5.Servers, len(*in))
+		for i := range *in {
+			if err := Convert_v1alpha3_Servers_To_v1alpha5_Servers(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
 	return nil
 }
 
@@ -1531,7 +1541,17 @@ func Convert_v1alpha3_ServersList_To_v1alpha5_ServersList(in *ServersList, out *
 
 func autoConvert_v1alpha5_ServersList_To_v1alpha3_ServersList(in *v1alpha5.ServersList, out *ServersList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]Servers)(unsafe.Pointer(&in.Items))
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]Servers, len(*in))
+		for i := range *in {
+			if err := Convert_v1alpha5_Servers_To_v1alpha3_Servers(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
 	return nil
 }
 
@@ -1609,7 +1629,17 @@ func Convert_v1alpha5_ServersSpecStorage_To_v1alpha3_ServersSpecStorage(in *v1al
 func autoConvert_v1alpha3_ServersStatus_To_v1alpha5_ServersStatus(in *ServersStatus, out *v1alpha5.ServersStatus, s conversion.Scope) error {
 	out.Ready = in.Ready
 	out.LastUpdate = (*metav1.MicroTime)(unsafe.Pointer(in.LastUpdate))
-	out.AllocationSets = *(*[]v1alpha5.ServersStatusAllocationSet)(unsafe.Pointer(&in.AllocationSets))
+	if in.AllocationSets != nil {
+		in, out := &in.AllocationSets, &out.AllocationSets
+		*out = make([]v1alpha5.ServersStatusAllocationSet, len(*in))
+		for i := range *in {
+			if err := Convert_v1alpha3_ServersStatusAllocationSet_To_v1alpha5_ServersStatusAllocationSet(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.AllocationSets = nil
+	}
 	if err := Convert_v1alpha3_ResourceError_To_v1alpha5_ResourceError(&in.ResourceError, &out.ResourceError, s); err != nil {
 		return err
 	}
@@ -1624,7 +1654,17 @@ func Convert_v1alpha3_ServersStatus_To_v1alpha5_ServersStatus(in *ServersStatus,
 func autoConvert_v1alpha5_ServersStatus_To_v1alpha3_ServersStatus(in *v1alpha5.ServersStatus, out *ServersStatus, s conversion.Scope) error {
 	out.Ready = in.Ready
 	out.LastUpdate = (*metav1.MicroTime)(unsafe.Pointer(in.LastUpdate))
-	out.AllocationSets = *(*[]ServersStatusAllocationSet)(unsafe.Pointer(&in.AllocationSets))
+	if in.AllocationSets != nil {
+		in, out := &in.AllocationSets, &out.AllocationSets
+		*out = make([]ServersStatusAllocationSet, len(*in))
+		for i := range *in {
+			if err := Convert_v1alpha5_ServersStatusAllocationSet_To_v1alpha3_ServersStatusAllocationSet(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.AllocationSets = nil
+	}
 	if err := Convert_v1alpha5_ResourceError_To_v1alpha3_ResourceError(&in.ResourceError, &out.ResourceError, s); err != nil {
 		return err
 	}
@@ -1638,7 +1678,19 @@ func Convert_v1alpha5_ServersStatus_To_v1alpha3_ServersStatus(in *v1alpha5.Serve
 
 func autoConvert_v1alpha3_ServersStatusAllocationSet_To_v1alpha5_ServersStatusAllocationSet(in *ServersStatusAllocationSet, out *v1alpha5.ServersStatusAllocationSet, s conversion.Scope) error {
 	out.Label = in.Label
-	out.Storage = *(*map[string]v1alpha5.ServersStatusStorage)(unsafe.Pointer(&in.Storage))
+	if in.Storage != nil {
+		in, out := &in.Storage, &out.Storage
+		*out = make(map[string]v1alpha5.ServersStatusStorage, len(*in))
+		for key, val := range *in {
+			newVal := new(v1alpha5.ServersStatusStorage)
+			if err := Convert_v1alpha3_ServersStatusStorage_To_v1alpha5_ServersStatusStorage(&val, newVal, s); err != nil {
+				return err
+			}
+			(*out)[key] = *newVal
+		}
+	} else {
+		out.Storage = nil
+	}
 	return nil
 }
 
@@ -1649,7 +1701,19 @@ func Convert_v1alpha3_ServersStatusAllocationSet_To_v1alpha5_ServersStatusAlloca
 
 func autoConvert_v1alpha5_ServersStatusAllocationSet_To_v1alpha3_ServersStatusAllocationSet(in *v1alpha5.ServersStatusAllocationSet, out *ServersStatusAllocationSet, s conversion.Scope) error {
 	out.Label = in.Label
-	out.Storage = *(*map[string]ServersStatusStorage)(unsafe.Pointer(&in.Storage))
+	if in.Storage != nil {
+		in, out := &in.Storage, &out.Storage
+		*out = make(map[string]ServersStatusStorage, len(*in))
+		for key, val := range *in {
+			newVal := new(ServersStatusStorage)
+			if err := Convert_v1alpha5_ServersStatusStorage_To_v1alpha3_ServersStatusStorage(&val, newVal, s); err != nil {
+				return err
+			}
+			(*out)[key] = *newVal
+		}
+	} else {
+		out.Storage = nil
+	}
 	return nil
 }
 
@@ -1670,12 +1734,8 @@ func Convert_v1alpha3_ServersStatusStorage_To_v1alpha5_ServersStatusStorage(in *
 
 func autoConvert_v1alpha5_ServersStatusStorage_To_v1alpha3_ServersStatusStorage(in *v1alpha5.ServersStatusStorage, out *ServersStatusStorage, s conversion.Scope) error {
 	out.AllocationSize = in.AllocationSize
+	// WARNING: in.Ready requires manual conversion: does not exist in peer-type
 	return nil
-}
-
-// Convert_v1alpha5_ServersStatusStorage_To_v1alpha3_ServersStatusStorage is an autogenerated conversion function.
-func Convert_v1alpha5_ServersStatusStorage_To_v1alpha3_ServersStatusStorage(in *v1alpha5.ServersStatusStorage, out *ServersStatusStorage, s conversion.Scope) error {
-	return autoConvert_v1alpha5_ServersStatusStorage_To_v1alpha3_ServersStatusStorage(in, out, s)
 }
 
 func autoConvert_v1alpha3_Storage_To_v1alpha5_Storage(in *Storage, out *v1alpha5.Storage, s conversion.Scope) error {
@@ -2144,7 +2204,17 @@ func Convert_v1alpha5_WorkflowDriverStatus_To_v1alpha3_WorkflowDriverStatus(in *
 
 func autoConvert_v1alpha3_WorkflowList_To_v1alpha5_WorkflowList(in *WorkflowList, out *v1alpha5.WorkflowList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]v1alpha5.Workflow)(unsafe.Pointer(&in.Items))
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]v1alpha5.Workflow, len(*in))
+		for i := range *in {
+			if err := Convert_v1alpha3_Workflow_To_v1alpha5_Workflow(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
 	return nil
 }
 
@@ -2155,7 +2225,17 @@ func Convert_v1alpha3_WorkflowList_To_v1alpha5_WorkflowList(in *WorkflowList, ou
 
 func autoConvert_v1alpha5_WorkflowList_To_v1alpha3_WorkflowList(in *v1alpha5.WorkflowList, out *WorkflowList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]Workflow)(unsafe.Pointer(&in.Items))
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]Workflow, len(*in))
+		for i := range *in {
+			if err := Convert_v1alpha5_Workflow_To_v1alpha3_Workflow(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
 	return nil
 }
 
@@ -2187,13 +2267,9 @@ func autoConvert_v1alpha5_WorkflowSpec_To_v1alpha3_WorkflowSpec(in *v1alpha5.Wor
 	out.UserID = in.UserID
 	out.GroupID = in.GroupID
 	out.Hurry = in.Hurry
+	// WARNING: in.ForceReady requires manual conversion: does not exist in peer-type
 	out.DWDirectives = *(*[]string)(unsafe.Pointer(&in.DWDirectives))
 	return nil
-}
-
-// Convert_v1alpha5_WorkflowSpec_To_v1alpha3_WorkflowSpec is an autogenerated conversion function.
-func Convert_v1alpha5_WorkflowSpec_To_v1alpha3_WorkflowSpec(in *v1alpha5.WorkflowSpec, out *WorkflowSpec, s conversion.Scope) error {
-	return autoConvert_v1alpha5_WorkflowSpec_To_v1alpha3_WorkflowSpec(in, out, s)
 }
 
 func autoConvert_v1alpha3_WorkflowStatus_To_v1alpha5_WorkflowStatus(in *WorkflowStatus, out *v1alpha5.WorkflowStatus, s conversion.Scope) error {

--- a/api/v1alpha4/conversion.go
+++ b/api/v1alpha4/conversion.go
@@ -21,6 +21,7 @@ package v1alpha4
 
 import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apiconversion "k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -201,12 +202,28 @@ func (src *Servers) ConvertTo(dstRaw conversion.Hub) error {
 
 	// Manually restore data.
 	restored := &dwsv1alpha5.Servers{}
-	if ok, err := utilconversion.UnmarshalData(src, restored); err != nil || !ok {
+	hasAnno, err := utilconversion.UnmarshalData(src, restored)
+	if err != nil {
 		return err
 	}
 	// EDIT THIS FUNCTION! If the annotation is holding anything that is
 	// hub-specific then copy it into 'dst' from 'restored'.
 	// Otherwise, you may comment out UnmarshalData() until it's needed.
+
+	if hasAnno {
+		for index := range dst.Status.AllocationSets {
+			if len(restored.Status.AllocationSets) < index {
+				break
+			}
+
+			for name := range dst.Status.AllocationSets[index].Storage {
+				if serverStatus, exists := restored.Status.AllocationSets[index].Storage[name]; exists {
+					serverStatus.AllocationSize = dst.Status.AllocationSets[index].Storage[name].AllocationSize
+					dst.Status.AllocationSets[index].Storage[name] = serverStatus
+				}
+			}
+		}
+	}
 
 	return nil
 }
@@ -329,12 +346,17 @@ func (src *Workflow) ConvertTo(dstRaw conversion.Hub) error {
 
 	// Manually restore data.
 	restored := &dwsv1alpha5.Workflow{}
-	if ok, err := utilconversion.UnmarshalData(src, restored); err != nil || !ok {
+	hasAnno, err := utilconversion.UnmarshalData(src, restored)
+	if err != nil {
 		return err
 	}
 	// EDIT THIS FUNCTION! If the annotation is holding anything that is
 	// hub-specific then copy it into 'dst' from 'restored'.
 	// Otherwise, you may comment out UnmarshalData() until it's needed.
+
+	if hasAnno {
+		dst.Spec.ForceReady = restored.Spec.ForceReady
+	}
 
 	return nil
 }
@@ -438,4 +460,15 @@ func (src *WorkflowList) ConvertTo(dstRaw conversion.Hub) error {
 
 func (dst *WorkflowList) ConvertFrom(srcRaw conversion.Hub) error {
 	return apierrors.NewMethodNotSupported(resource("WorkflowList"), "ConvertFrom")
+}
+
+// The conversion-gen tool dropped these from zz_generated.conversion.go to
+// force us to acknowledge that we are addressing the conversion requirements.
+
+func Convert_v1alpha5_ServersStatusStorage_To_v1alpha4_ServersStatusStorage(in *dwsv1alpha5.ServersStatusStorage, out *ServersStatusStorage, s apiconversion.Scope) error {
+	return autoConvert_v1alpha5_ServersStatusStorage_To_v1alpha4_ServersStatusStorage(in, out, s)
+}
+
+func Convert_v1alpha5_WorkflowSpec_To_v1alpha4_WorkflowSpec(in *dwsv1alpha5.WorkflowSpec, out *WorkflowSpec, s apiconversion.Scope) error {
+	return autoConvert_v1alpha5_WorkflowSpec_To_v1alpha4_WorkflowSpec(in, out, s)
 }

--- a/api/v1alpha4/zz_generated.conversion.go
+++ b/api/v1alpha4/zz_generated.conversion.go
@@ -448,11 +448,6 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*v1alpha5.ServersStatusStorage)(nil), (*ServersStatusStorage)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1alpha5_ServersStatusStorage_To_v1alpha4_ServersStatusStorage(a.(*v1alpha5.ServersStatusStorage), b.(*ServersStatusStorage), scope)
-	}); err != nil {
-		return err
-	}
 	if err := s.AddGeneratedConversionFunc((*Storage)(nil), (*v1alpha5.Storage)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1alpha4_Storage_To_v1alpha5_Storage(a.(*Storage), b.(*v1alpha5.Storage), scope)
 	}); err != nil {
@@ -668,11 +663,6 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*v1alpha5.WorkflowSpec)(nil), (*WorkflowSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1alpha5_WorkflowSpec_To_v1alpha4_WorkflowSpec(a.(*v1alpha5.WorkflowSpec), b.(*WorkflowSpec), scope)
-	}); err != nil {
-		return err
-	}
 	if err := s.AddGeneratedConversionFunc((*WorkflowStatus)(nil), (*v1alpha5.WorkflowStatus)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1alpha4_WorkflowStatus_To_v1alpha5_WorkflowStatus(a.(*WorkflowStatus), b.(*v1alpha5.WorkflowStatus), scope)
 	}); err != nil {
@@ -690,6 +680,16 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}
 	if err := s.AddGeneratedConversionFunc((*v1alpha5.WorkflowTokenSecret)(nil), (*WorkflowTokenSecret)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1alpha5_WorkflowTokenSecret_To_v1alpha4_WorkflowTokenSecret(a.(*v1alpha5.WorkflowTokenSecret), b.(*WorkflowTokenSecret), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddConversionFunc((*v1alpha5.ServersStatusStorage)(nil), (*ServersStatusStorage)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1alpha5_ServersStatusStorage_To_v1alpha4_ServersStatusStorage(a.(*v1alpha5.ServersStatusStorage), b.(*ServersStatusStorage), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddConversionFunc((*v1alpha5.WorkflowSpec)(nil), (*WorkflowSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1alpha5_WorkflowSpec_To_v1alpha4_WorkflowSpec(a.(*v1alpha5.WorkflowSpec), b.(*WorkflowSpec), scope)
 	}); err != nil {
 		return err
 	}
@@ -1550,7 +1550,17 @@ func Convert_v1alpha5_Servers_To_v1alpha4_Servers(in *v1alpha5.Servers, out *Ser
 
 func autoConvert_v1alpha4_ServersList_To_v1alpha5_ServersList(in *ServersList, out *v1alpha5.ServersList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]v1alpha5.Servers)(unsafe.Pointer(&in.Items))
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]v1alpha5.Servers, len(*in))
+		for i := range *in {
+			if err := Convert_v1alpha4_Servers_To_v1alpha5_Servers(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
 	return nil
 }
 
@@ -1561,7 +1571,17 @@ func Convert_v1alpha4_ServersList_To_v1alpha5_ServersList(in *ServersList, out *
 
 func autoConvert_v1alpha5_ServersList_To_v1alpha4_ServersList(in *v1alpha5.ServersList, out *ServersList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]Servers)(unsafe.Pointer(&in.Items))
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]Servers, len(*in))
+		for i := range *in {
+			if err := Convert_v1alpha5_Servers_To_v1alpha4_Servers(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
 	return nil
 }
 
@@ -1639,7 +1659,17 @@ func Convert_v1alpha5_ServersSpecStorage_To_v1alpha4_ServersSpecStorage(in *v1al
 func autoConvert_v1alpha4_ServersStatus_To_v1alpha5_ServersStatus(in *ServersStatus, out *v1alpha5.ServersStatus, s conversion.Scope) error {
 	out.Ready = in.Ready
 	out.LastUpdate = (*metav1.MicroTime)(unsafe.Pointer(in.LastUpdate))
-	out.AllocationSets = *(*[]v1alpha5.ServersStatusAllocationSet)(unsafe.Pointer(&in.AllocationSets))
+	if in.AllocationSets != nil {
+		in, out := &in.AllocationSets, &out.AllocationSets
+		*out = make([]v1alpha5.ServersStatusAllocationSet, len(*in))
+		for i := range *in {
+			if err := Convert_v1alpha4_ServersStatusAllocationSet_To_v1alpha5_ServersStatusAllocationSet(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.AllocationSets = nil
+	}
 	if err := Convert_v1alpha4_ResourceError_To_v1alpha5_ResourceError(&in.ResourceError, &out.ResourceError, s); err != nil {
 		return err
 	}
@@ -1654,7 +1684,17 @@ func Convert_v1alpha4_ServersStatus_To_v1alpha5_ServersStatus(in *ServersStatus,
 func autoConvert_v1alpha5_ServersStatus_To_v1alpha4_ServersStatus(in *v1alpha5.ServersStatus, out *ServersStatus, s conversion.Scope) error {
 	out.Ready = in.Ready
 	out.LastUpdate = (*metav1.MicroTime)(unsafe.Pointer(in.LastUpdate))
-	out.AllocationSets = *(*[]ServersStatusAllocationSet)(unsafe.Pointer(&in.AllocationSets))
+	if in.AllocationSets != nil {
+		in, out := &in.AllocationSets, &out.AllocationSets
+		*out = make([]ServersStatusAllocationSet, len(*in))
+		for i := range *in {
+			if err := Convert_v1alpha5_ServersStatusAllocationSet_To_v1alpha4_ServersStatusAllocationSet(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.AllocationSets = nil
+	}
 	if err := Convert_v1alpha5_ResourceError_To_v1alpha4_ResourceError(&in.ResourceError, &out.ResourceError, s); err != nil {
 		return err
 	}
@@ -1668,7 +1708,19 @@ func Convert_v1alpha5_ServersStatus_To_v1alpha4_ServersStatus(in *v1alpha5.Serve
 
 func autoConvert_v1alpha4_ServersStatusAllocationSet_To_v1alpha5_ServersStatusAllocationSet(in *ServersStatusAllocationSet, out *v1alpha5.ServersStatusAllocationSet, s conversion.Scope) error {
 	out.Label = in.Label
-	out.Storage = *(*map[string]v1alpha5.ServersStatusStorage)(unsafe.Pointer(&in.Storage))
+	if in.Storage != nil {
+		in, out := &in.Storage, &out.Storage
+		*out = make(map[string]v1alpha5.ServersStatusStorage, len(*in))
+		for key, val := range *in {
+			newVal := new(v1alpha5.ServersStatusStorage)
+			if err := Convert_v1alpha4_ServersStatusStorage_To_v1alpha5_ServersStatusStorage(&val, newVal, s); err != nil {
+				return err
+			}
+			(*out)[key] = *newVal
+		}
+	} else {
+		out.Storage = nil
+	}
 	return nil
 }
 
@@ -1679,7 +1731,19 @@ func Convert_v1alpha4_ServersStatusAllocationSet_To_v1alpha5_ServersStatusAlloca
 
 func autoConvert_v1alpha5_ServersStatusAllocationSet_To_v1alpha4_ServersStatusAllocationSet(in *v1alpha5.ServersStatusAllocationSet, out *ServersStatusAllocationSet, s conversion.Scope) error {
 	out.Label = in.Label
-	out.Storage = *(*map[string]ServersStatusStorage)(unsafe.Pointer(&in.Storage))
+	if in.Storage != nil {
+		in, out := &in.Storage, &out.Storage
+		*out = make(map[string]ServersStatusStorage, len(*in))
+		for key, val := range *in {
+			newVal := new(ServersStatusStorage)
+			if err := Convert_v1alpha5_ServersStatusStorage_To_v1alpha4_ServersStatusStorage(&val, newVal, s); err != nil {
+				return err
+			}
+			(*out)[key] = *newVal
+		}
+	} else {
+		out.Storage = nil
+	}
 	return nil
 }
 
@@ -1700,12 +1764,8 @@ func Convert_v1alpha4_ServersStatusStorage_To_v1alpha5_ServersStatusStorage(in *
 
 func autoConvert_v1alpha5_ServersStatusStorage_To_v1alpha4_ServersStatusStorage(in *v1alpha5.ServersStatusStorage, out *ServersStatusStorage, s conversion.Scope) error {
 	out.AllocationSize = in.AllocationSize
+	// WARNING: in.Ready requires manual conversion: does not exist in peer-type
 	return nil
-}
-
-// Convert_v1alpha5_ServersStatusStorage_To_v1alpha4_ServersStatusStorage is an autogenerated conversion function.
-func Convert_v1alpha5_ServersStatusStorage_To_v1alpha4_ServersStatusStorage(in *v1alpha5.ServersStatusStorage, out *ServersStatusStorage, s conversion.Scope) error {
-	return autoConvert_v1alpha5_ServersStatusStorage_To_v1alpha4_ServersStatusStorage(in, out, s)
 }
 
 func autoConvert_v1alpha4_Storage_To_v1alpha5_Storage(in *Storage, out *v1alpha5.Storage, s conversion.Scope) error {
@@ -2242,7 +2302,17 @@ func Convert_v1alpha5_WorkflowDriverStatus_To_v1alpha4_WorkflowDriverStatus(in *
 
 func autoConvert_v1alpha4_WorkflowList_To_v1alpha5_WorkflowList(in *WorkflowList, out *v1alpha5.WorkflowList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]v1alpha5.Workflow)(unsafe.Pointer(&in.Items))
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]v1alpha5.Workflow, len(*in))
+		for i := range *in {
+			if err := Convert_v1alpha4_Workflow_To_v1alpha5_Workflow(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
 	return nil
 }
 
@@ -2253,7 +2323,17 @@ func Convert_v1alpha4_WorkflowList_To_v1alpha5_WorkflowList(in *WorkflowList, ou
 
 func autoConvert_v1alpha5_WorkflowList_To_v1alpha4_WorkflowList(in *v1alpha5.WorkflowList, out *WorkflowList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]Workflow)(unsafe.Pointer(&in.Items))
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]Workflow, len(*in))
+		for i := range *in {
+			if err := Convert_v1alpha5_Workflow_To_v1alpha4_Workflow(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
 	return nil
 }
 
@@ -2285,13 +2365,9 @@ func autoConvert_v1alpha5_WorkflowSpec_To_v1alpha4_WorkflowSpec(in *v1alpha5.Wor
 	out.UserID = in.UserID
 	out.GroupID = in.GroupID
 	out.Hurry = in.Hurry
+	// WARNING: in.ForceReady requires manual conversion: does not exist in peer-type
 	out.DWDirectives = *(*[]string)(unsafe.Pointer(&in.DWDirectives))
 	return nil
-}
-
-// Convert_v1alpha5_WorkflowSpec_To_v1alpha4_WorkflowSpec is an autogenerated conversion function.
-func Convert_v1alpha5_WorkflowSpec_To_v1alpha4_WorkflowSpec(in *v1alpha5.WorkflowSpec, out *WorkflowSpec, s conversion.Scope) error {
-	return autoConvert_v1alpha5_WorkflowSpec_To_v1alpha4_WorkflowSpec(in, out, s)
 }
 
 func autoConvert_v1alpha4_WorkflowStatus_To_v1alpha5_WorkflowStatus(in *WorkflowStatus, out *v1alpha5.WorkflowStatus, s conversion.Scope) error {

--- a/api/v1alpha5/servers_types.go
+++ b/api/v1alpha5/servers_types.go
@@ -63,6 +63,9 @@ type ServersSpec struct {
 type ServersStatusStorage struct {
 	// Allocation size in bytes
 	AllocationSize int64 `json:"allocationSize"`
+
+	// Ready indicates whether all the allocatoons on the server have been successfully created
+	Ready bool `json:"ready"`
 }
 
 // ServersStatusAllocationSet is the status of a set of allocations

--- a/api/v1alpha5/servers_types.go
+++ b/api/v1alpha5/servers_types.go
@@ -64,7 +64,7 @@ type ServersStatusStorage struct {
 	// Allocation size in bytes
 	AllocationSize int64 `json:"allocationSize"`
 
-	// Ready indicates whether all the allocatoons on the server have been successfully created
+	// Ready indicates whether all the allocations on the server have been successfully created
 	Ready bool `json:"ready"`
 }
 

--- a/api/v1alpha5/workflow_types.go
+++ b/api/v1alpha5/workflow_types.go
@@ -168,6 +168,11 @@ type WorkflowSpec struct {
 	// +kubebuilder:default:=false
 	Hurry bool `json:"hurry,omitempty"`
 
+	// ForceReady will cause the workflow to move to 'Ready' even if the underlying drivers haven't finished. This should only be used when the
+	// driver supports it.
+	// +kubebuilder:default:=false
+	ForceReady bool `json:"forceReady"`
+
 	// List of #DW strings from a WLM job script
 	DWDirectives []string `json:"dwDirectives"`
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -158,16 +158,13 @@ func main() {
 			setupLog.Error(err, "unable to create webhook", "webhook", "Workflow")
 			os.Exit(1)
 		}
-	default:
-		setupLog.Info("unsupported mode", "mode", mode)
-		os.Exit(1)
-	}
-
-	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
 		if err = (&dwsv1alpha5.SystemStatus{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "SystemStatus")
 			os.Exit(1)
 		}
+	default:
+		setupLog.Info("unsupported mode", "mode", mode)
+		os.Exit(1)
 	}
 	//+kubebuilder:scaffold:builder
 

--- a/config/crd/bases/dataworkflowservices.github.io_servers.yaml
+++ b/config/crd/bases/dataworkflowservices.github.io_servers.yaml
@@ -707,7 +707,7 @@ spec:
                             format: int64
                             type: integer
                           ready:
-                            description: Ready indicates whether all the allocatoons
+                            description: Ready indicates whether all the allocations
                               on the server have been successfully created
                             type: boolean
                         required:

--- a/config/crd/bases/dataworkflowservices.github.io_servers.yaml
+++ b/config/crd/bases/dataworkflowservices.github.io_servers.yaml
@@ -706,8 +706,13 @@ spec:
                             description: Allocation size in bytes
                             format: int64
                             type: integer
+                          ready:
+                            description: Ready indicates whether all the allocatoons
+                              on the server have been successfully created
+                            type: boolean
                         required:
                         - allocationSize
+                        - ready
                         type: object
                       description: List of storage resources that have allocations
                       type: object

--- a/config/crd/bases/dataworkflowservices.github.io_workflows.yaml
+++ b/config/crd/bases/dataworkflowservices.github.io_workflows.yaml
@@ -1531,6 +1531,12 @@ spec:
                 items:
                   type: string
                 type: array
+              forceReady:
+                default: false
+                description: |-
+                  ForceReady will cause the workflow to move to 'Ready' even if the underlying drivers haven't finished. This should only be used when the
+                  driver supports it.
+                type: boolean
               groupID:
                 description: |-
                   GroupID specifies the group ID for the workflow. The Group ID is used by the various states
@@ -1568,6 +1574,7 @@ spec:
             required:
             - desiredState
             - dwDirectives
+            - forceReady
             - groupID
             - jobID
             - userID

--- a/controllers/workflow_controller.go
+++ b/controllers/workflow_controller.go
@@ -134,6 +134,7 @@ func (r *WorkflowReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 	// Need to set Status.State first because the webhook validates this.
 	if workflow.Status.State != workflow.Spec.DesiredState {
 		log.Info("Workflow state transitioning", "state", workflow.Spec.DesiredState)
+		workflow.Spec.ForceReady = ConditionFalse
 		workflow.Status.State = workflow.Spec.DesiredState
 		workflow.Status.Ready = ConditionFalse
 		workflow.Status.Status = dwsv1alpha5.StatusDriverWait
@@ -225,6 +226,13 @@ func (r *WorkflowReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 				workflow.Status.Status = dwsv1alpha5.StatusDriverWait
 			}
 		}
+	}
+
+	if workflow.Spec.ForceReady {
+		workflow.Status.Ready = true
+		workflow.Status.Status = dwsv1alpha5.StatusCompleted
+		workflow.Status.Message = "Forced Ready"
+		log.Info("Workflow transitioning to ready with ForceReady")
 	}
 
 	if workflow.Status.Ready == true {


### PR DESCRIPTION
Add a new field, spec.forceReady, to the Workflow resource that will cause the Workflow to be marked as status.ready=true even if the underlying drivers have not completed. The spec.forceReady field will be reset after the spec.desiredState is advanced to the next state.