### PR TITLE
Fix kube-rbac-proxy image registry: gcr.io -> registry.k8s.io

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1
+        image: registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.14.1
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
Google deprecated gcr.io and removed the kube-rbac-proxy image. This causes `ImagePullBackOff` failures when deploying to environments without a registry mirror (e.g., KIND clusters).

Update the image reference from `gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1` to `registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.14.1`, which is the official replacement registry.