### PR TITLE
Add validation webhook to make PersistentStorageInstance immutable

### DIFF
--- a/api/v1alpha7/persistentstorageinstance_webhook.go
+++ b/api/v1alpha7/persistentstorageinstance_webhook.go
@@ -20,8 +20,14 @@
 package v1alpha7
 
 import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 // log is for logging in this package.
@@ -34,4 +40,59 @@ func (r *PersistentStorageInstance) SetupWebhookWithManager(mgr ctrl.Manager) er
 		Complete()
 }
 
-// TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
+// NOTE: The 'path' attribute must follow a specific pattern and should not be modified directly here.
+// Modifying the path for an invalid path can cause API server errors; failing to locate the webhook.
+//+kubebuilder:webhook:path=/validate-dataworkflowservices-github-io-v1alpha7-persistentstorageinstance,mutating=false,failurePolicy=fail,sideEffects=None,groups=dataworkflowservices.github.io,resources=persistentstorageinstances,verbs=create;update,versions=v1alpha7,name=vpersistentstorageinstance.kb.io,admissionReviewVersions={v1,v1beta1}
+
+var _ webhook.Validator = &PersistentStorageInstance{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (r *PersistentStorageInstance) ValidateCreate() (admission.Warnings, error) {
+	persistentstorageinstancelog.Info("validate-create", "name", r.Name)
+
+	if r.Spec.State != PSIStateActive {
+		s := fmt.Sprintf("spec.state must be %s on creation", PSIStateActive)
+		return nil, field.Invalid(field.NewPath("Spec").Child("State"), r.Spec.State, s)
+	}
+
+	return nil, nil
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (r *PersistentStorageInstance) ValidateUpdate(old runtime.Object) (admission.Warnings, error) {
+	persistentstorageinstancelog.Info("validate-update", "name", r.Name)
+
+	oldPSI, ok := old.(*PersistentStorageInstance)
+	if !ok {
+		err := fmt.Errorf("invalid PersistentStorageInstance resource")
+		persistentstorageinstancelog.Error(err, "old runtime.Object is not a PersistentStorageInstance resource")
+		return nil, err
+	}
+
+	immutableError := func(childField string) error {
+		return field.Forbidden(field.NewPath("Spec").Child(childField), "field is immutable")
+	}
+
+	if r.Spec.Name != oldPSI.Spec.Name {
+		return nil, immutableError("Name")
+	}
+
+	if r.Spec.FsType != oldPSI.Spec.FsType {
+		return nil, immutableError("FsType")
+	}
+
+	if r.Spec.DWDirective != oldPSI.Spec.DWDirective {
+		return nil, immutableError("DWDirective")
+	}
+
+	if r.Spec.UserID != oldPSI.Spec.UserID {
+		return nil, immutableError("UserID")
+	}
+
+	return nil, nil
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (r *PersistentStorageInstance) ValidateDelete() (admission.Warnings, error) {
+	return nil, nil
+}

--- a/api/v1alpha7/persistentstorageinstance_webhook_test.go
+++ b/api/v1alpha7/persistentstorageinstance_webhook_test.go
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2025 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v1alpha7
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("PersistentStorageInstance Webhook", func() {
+
+	var (
+		psi *PersistentStorageInstance
+	)
+
+	BeforeEach(func() {
+		psiid := uuid.NewString()[0:8]
+		psi = &PersistentStorageInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("psi-%s", psiid),
+				Namespace: metav1.NamespaceDefault,
+			},
+			Spec: PersistentStorageInstanceSpec{
+				Name:        fmt.Sprintf("psi-%s", psiid),
+				FsType:      "lustre",
+				DWDirective: "#DW create_persistent name=psi type=lustre capacity=1GiB",
+				UserID:      1000,
+				State:       PSIStateActive,
+			},
+		}
+	})
+
+	AfterEach(func() {
+		if psi != nil {
+			Expect(k8sClient.Delete(context.TODO(), psi)).To(Succeed())
+		}
+	})
+
+	It("should create a PersistentStorageInstance with valid spec", func() {
+		Expect(k8sClient.Create(context.TODO(), psi)).To(Succeed())
+	})
+
+	It("should fail to create when spec.state is not Active", func() {
+		psi.Spec.State = PSIStateDestroying
+		Expect(k8sClient.Create(context.TODO(), psi)).ShouldNot(Succeed())
+		psi = nil
+	})
+
+	Describe("Immutable fields after create", Ordered, func() {
+		BeforeEach(func() {
+			Expect(k8sClient.Create(context.TODO(), psi)).Should(Succeed())
+		})
+
+		It("should reject changes to FsType", func() {
+			psi.Spec.FsType = "xfs"
+			Expect(k8sClient.Update(context.TODO(), psi)).ShouldNot(Succeed())
+		})
+
+		It("should reject changes to DWDirective", func() {
+			psi.Spec.DWDirective = "#DW create_persistent name=psi type=lustre capacity=10GiB"
+			Expect(k8sClient.Update(context.TODO(), psi)).ShouldNot(Succeed())
+		})
+
+		It("should reject changes to Name", func() {
+			psi.Spec.Name = "different-name"
+			Expect(k8sClient.Update(context.TODO(), psi)).ShouldNot(Succeed())
+		})
+
+		It("should reject changes to UserID", func() {
+			psi.Spec.UserID = 9999
+			Expect(k8sClient.Update(context.TODO(), psi)).ShouldNot(Succeed())
+		})
+
+		It("should allow transitioning State to Destroying", func() {
+			psi.Spec.State = PSIStateDestroying
+			Expect(k8sClient.Update(context.TODO(), psi)).Should(Succeed())
+		})
+	})
+})

--- a/api/v1alpha7/webhook_suite_test.go
+++ b/api/v1alpha7/webhook_suite_test.go
@@ -116,6 +116,9 @@ var _ = BeforeSuite(func() {
 	err = (&Workflow{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
+	err = (&PersistentStorageInstance{}).SetupWebhookWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
 	//+kubebuilder:scaffold:webhook
 
 	go func() {

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -37,6 +37,27 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-dataworkflowservices-github-io-v1alpha7-persistentstorageinstance
+  failurePolicy: Fail
+  name: vpersistentstorageinstance.kb.io
+  rules:
+  - apiGroups:
+    - dataworkflowservices.github.io
+    apiVersions:
+    - v1alpha7
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - persistentstorageinstances
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-dataworkflowservices-github-io-v1alpha7-workflow
   failurePolicy: Fail
   name: vworkflow.kb.io


### PR DESCRIPTION
Fixes https://github.com/NearNodeFlash/NearNodeFlash.github.io/issues/86

Users were able to modify fields on a `PersistentStorageInstance` after creation — including changing `fsType` (e.g. `lustre` → `xfs`) and storage size — which is not supported and led to failures.

## Changes

- Implement `ValidateCreate` and `ValidateUpdate` on `PersistentStorageInstance` in `api/v1alpha7/persistentstorageinstance_webhook.go`:
  - `ValidateCreate`: requires `spec.state` to be `Active` on creation
  - `ValidateUpdate`: enforces immutability of `spec.name`, `spec.fsType`, `spec.dwDirective`, and `spec.userID`
- Add the `vpersistentstorageinstance.kb.io` validating webhook entry to `config/webhook/manifests.yaml`
- Register the PSI webhook in `api/v1alpha7/webhook_suite_test.go`
- Add `api/v1alpha7/persistentstorageinstance_webhook_test.go` with full coverage of create and update validation