### PR TITLE
Allow PSI UID bypass via annotation and relax webhook admission checks

### DIFF
--- a/api/v1alpha7/persistentstorageinstance_types.go
+++ b/api/v1alpha7/persistentstorageinstance_types.go
@@ -33,6 +33,17 @@ const (
 
 	// PersistentStorageNamespaceLabel is defined for resources that relate to the namespace of a DWS PersistentStorageInstance
 	PersistentStorageNamespaceLabel = "dataworkflowservices.github.io/persistentstorage.namespace"
+
+	// PersistentStorageIgnoreUIDAnnotation allows workflow admission for a
+	// persistentdw directive to bypass the check that workflow.spec.userID
+	// matches PersistentStorageInstance.spec.userID.
+	//
+	// This annotation applies only to persistentdw. It does not apply to
+	// destroy_persistent, which still requires a matching userID.
+	//
+	// PersistentStorageInstance.spec.userID is mutable, so changing it may
+	// affect admission decisions for later workflows that reference the PSI.
+	PersistentStorageIgnoreUIDAnnotation = "dataworkflowservices.github.io/ignore-uid"
 )
 
 // PersistentStorageInstanceState specifies the golang type for PSIState

--- a/api/v1alpha7/persistentstorageinstance_webhook.go
+++ b/api/v1alpha7/persistentstorageinstance_webhook.go
@@ -85,10 +85,6 @@ func (r *PersistentStorageInstance) ValidateUpdate(old runtime.Object) (admissio
 		return nil, immutableError("DWDirective")
 	}
 
-	if r.Spec.UserID != oldPSI.Spec.UserID {
-		return nil, immutableError("UserID")
-	}
-
 	return nil, nil
 }
 

--- a/api/v1alpha7/persistentstorageinstance_webhook_test.go
+++ b/api/v1alpha7/persistentstorageinstance_webhook_test.go
@@ -88,9 +88,9 @@ var _ = Describe("PersistentStorageInstance Webhook", func() {
 			Expect(k8sClient.Update(context.TODO(), psi)).ShouldNot(Succeed())
 		})
 
-		It("should reject changes to UserID", func() {
+		It("should allow changes to UserID", func() {
 			psi.Spec.UserID = 9999
-			Expect(k8sClient.Update(context.TODO(), psi)).ShouldNot(Succeed())
+			Expect(k8sClient.Update(context.TODO(), psi)).Should(Succeed())
 		})
 
 		It("should allow transitioning State to Destroying", func() {

--- a/api/v1alpha7/workflow_webhook.go
+++ b/api/v1alpha7/workflow_webhook.go
@@ -377,7 +377,9 @@ func validatePersistentInstanceDirective(workflow *Workflow, index int) error {
 	// migrate to CustomValidator to enable proper context propagation.
 	if err := c.Get(context.TODO(), key, psi); err != nil {
 		if apierrors.IsNotFound(err) {
-			return field.Invalid(field.NewPath("Spec").Child("DWDirectives").Index(index), workflow.Spec.DWDirectives[index], fmt.Sprintf("persistent storage instance %q not found", name))
+			// PSI may not exist yet (e.g., create_persistent workflow still reconciling).
+			// Defer existence validation to the reconciler which retries.
+			return nil
 		}
 
 		return err

--- a/api/v1alpha7/workflow_webhook.go
+++ b/api/v1alpha7/workflow_webhook.go
@@ -27,6 +27,7 @@ import (
 	"reflect"
 	"strings"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -39,6 +40,7 @@ import (
 )
 
 //+kubebuilder:rbac:groups=dataworkflowservices.github.io,resources=dwdirectiverules,verbs=get;list;watch
+//+kubebuilder:rbac:groups=dataworkflowservices.github.io,resources=persistentstorageinstances,verbs=get
 
 // log is for logging in this package.
 var workflowlog = logf.Log.WithName("workflow-resource")
@@ -230,8 +232,8 @@ func checkDirectives(workflow *Workflow, ruleParser RuleParser) error {
 	}
 
 	// Forward the rule and directive index to the rule parsers matched directive handling
-	onValidDirectiveFunc := func(index int, rule dwdparse.DWDirectiveRuleSpec) {
-		ruleParser.MatchedDirective(workflow, rule.WatchStates, index, rule.DriverLabel)
+	onValidDirectiveFunc := func(index int, rule dwdparse.DWDirectiveRuleSpec) error {
+		return ruleParser.MatchedDirective(workflow, rule.WatchStates, index, rule.DriverLabel)
 	}
 
 	return dwdparse.Validate(ruleParser.GetRuleList(), workflow.Spec.DWDirectives, onValidDirectiveFunc)
@@ -242,7 +244,7 @@ func checkDirectives(workflow *Workflow, ruleParser RuleParser) error {
 type RuleParser interface {
 	ReadRules() error
 	GetRuleList() []dwdparse.DWDirectiveRuleSpec
-	MatchedDirective(*Workflow, string, int, string)
+	MatchedDirective(*Workflow, string, int, string) error
 }
 
 // RuleList contains the rules to be applied for a particular driver
@@ -296,10 +298,10 @@ type MutatingRuleParser struct {
 }
 
 // MatchedDirective updates the driver status entries to indicate driver availability
-func (r *MutatingRuleParser) MatchedDirective(workflow *Workflow, watchStates string, index int, label string) {
+func (r *MutatingRuleParser) MatchedDirective(workflow *Workflow, watchStates string, index int, label string) error {
 	if len(watchStates) == 0 {
 		// Nothing to do
-		return
+		return nil
 	}
 
 	registrationMap := make(map[WorkflowState]bool)
@@ -335,6 +337,8 @@ func (r *MutatingRuleParser) MatchedDirective(workflow *Workflow, watchStates st
 		workflow.Status.Drivers = append(workflow.Status.Drivers, driverStatus)
 		workflowlog.Info("Registering driver", "Driver", driverStatus.DriverID, "Watch state", state)
 	}
+
+	return nil
 }
 
 // ValidatingRuleParser implements the RuleParser interface.
@@ -347,5 +351,45 @@ type ValidatingRuleParser struct {
 }
 
 // MatchedDirective provides the interface function for the validating webhook
-func (r *ValidatingRuleParser) MatchedDirective(workflow *Workflow, watchStates string, index int, label string) {
+func (r *ValidatingRuleParser) MatchedDirective(workflow *Workflow, watchStates string, index int, label string) error {
+	return validatePersistentInstanceDirective(workflow, index)
+}
+
+func validatePersistentInstanceDirective(workflow *Workflow, index int) error {
+	argsMap, err := dwdparse.BuildArgsMap(workflow.Spec.DWDirectives[index])
+	if err != nil {
+		return err
+	}
+
+	command := argsMap["command"]
+	if command != "persistentdw" && command != "destroy_persistent" {
+		return nil
+	}
+
+	name, ok := argsMap["name"]
+	if !ok {
+		return field.Required(field.NewPath("Spec").Child("DWDirectives").Index(index), fmt.Sprintf("%s directives require a name", command))
+	}
+
+	psi := &PersistentStorageInstance{}
+	key := client.ObjectKey{Name: name, Namespace: workflow.Namespace}
+	// NOTE: The Validator interface does not propagate request context;
+	// migrate to CustomValidator to enable proper context propagation.
+	if err := c.Get(context.TODO(), key, psi); err != nil {
+		if apierrors.IsNotFound(err) {
+			return field.Invalid(field.NewPath("Spec").Child("DWDirectives").Index(index), workflow.Spec.DWDirectives[index], fmt.Sprintf("persistent storage instance %q not found", name))
+		}
+
+		return err
+	}
+
+	if command == "persistentdw" && strings.EqualFold(psi.Annotations[PersistentStorageIgnoreUIDAnnotation], "true") {
+		return nil
+	}
+
+	if psi.Spec.UserID != workflow.Spec.UserID {
+		return field.Forbidden(field.NewPath("Spec").Child("DWDirectives").Index(index), fmt.Sprintf("workflow userID %d does not match persistent storage instance %q userID %d", workflow.Spec.UserID, name, psi.Spec.UserID))
+	}
+
+	return nil
 }

--- a/api/v1alpha7/workflow_webhook_test.go
+++ b/api/v1alpha7/workflow_webhook_test.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/DataWorkflowServices/dws/utils/dwdparse"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -140,5 +141,100 @@ var _ = Describe("Workflow Webhook", func() {
 			Entry("When Spec.DesiredState PostRun", StatePostRun),
 			Entry("When Spec.DesiredState DataOut", StateDataOut),
 		)
+	})
+
+	Describe("Persistent storage directive userID validation", func() {
+		var (
+			psi  *PersistentStorageInstance
+			rule *DWDirectiveRule
+		)
+
+		BeforeEach(func() {
+			workflow.Spec.UserID = 1000
+			workflow.Spec.DWDirectives = []string{"#DW persistentdw name=shared-psi"}
+
+			psi = &PersistentStorageInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "shared-psi",
+					Namespace: workflow.Namespace,
+				},
+				Spec: PersistentStorageInstanceSpec{
+					Name:        "shared-psi",
+					FsType:      "lustre",
+					DWDirective: "#DW create_persistent name=shared-psi type=lustre capacity=1GiB",
+					UserID:      2000,
+					State:       PSIStateActive,
+				},
+			}
+
+			rule = &DWDirectiveRule{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("rules-%s", uuid.NewString()[0:8]),
+					Namespace: workflow.Namespace,
+				},
+				Spec: []dwdparse.DWDirectiveRuleSpec{
+					{
+						Command: "persistentdw",
+						RuleDefs: []dwdparse.DWDirectiveRuleDef{{
+							Key:             "name",
+							Type:            "string",
+							Pattern:         "^([A-Za-z0-9_-]+)$",
+							IsRequired:      true,
+							IsValueRequired: true,
+						}},
+					},
+					{
+						Command: "destroy_persistent",
+						RuleDefs: []dwdparse.DWDirectiveRuleDef{{
+							Key:             "name",
+							Type:            "string",
+							Pattern:         "^([A-Za-z0-9_-]+)$",
+							IsRequired:      true,
+							IsValueRequired: true,
+						}},
+					},
+				},
+			}
+
+			Expect(k8sClient.Create(context.TODO(), rule)).To(Succeed())
+			Expect(k8sClient.Create(context.TODO(), psi)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			if psi != nil {
+				Expect(k8sClient.Delete(context.TODO(), psi)).To(Succeed())
+			}
+
+			if rule != nil {
+				Expect(k8sClient.Delete(context.TODO(), rule)).To(Succeed())
+			}
+		})
+
+		It("rejects a persistentdw request when workflow and PSI userIDs differ", func() {
+			Expect(k8sClient.Create(context.TODO(), workflow)).ShouldNot(Succeed())
+			workflow = nil
+		})
+
+		It("allows a persistentdw request when the PSI opts out of the userID check", func() {
+			psi.Annotations = map[string]string{PersistentStorageIgnoreUIDAnnotation: "true"}
+			Expect(k8sClient.Update(context.TODO(), psi)).To(Succeed())
+
+			Expect(k8sClient.Create(context.TODO(), workflow)).To(Succeed())
+		})
+
+		It("rejects a destroy_persistent request when workflow and PSI userIDs differ", func() {
+			workflow.Spec.DWDirectives = []string{"#DW destroy_persistent name=shared-psi"}
+			Expect(k8sClient.Create(context.TODO(), workflow)).ShouldNot(Succeed())
+			workflow = nil
+		})
+
+		It("rejects a destroy_persistent request even when the PSI opts out of the userID check", func() {
+			workflow.Spec.DWDirectives = []string{"#DW destroy_persistent name=shared-psi"}
+			psi.Annotations = map[string]string{PersistentStorageIgnoreUIDAnnotation: "true"}
+			Expect(k8sClient.Update(context.TODO(), psi)).To(Succeed())
+
+			Expect(k8sClient.Create(context.TODO(), workflow)).ShouldNot(Succeed())
+			workflow = nil
+		})
 	})
 })

--- a/api/v1alpha7/workflow_webhook_test.go
+++ b/api/v1alpha7/workflow_webhook_test.go
@@ -236,5 +236,20 @@ var _ = Describe("Workflow Webhook", func() {
 			Expect(k8sClient.Create(context.TODO(), workflow)).ShouldNot(Succeed())
 			workflow = nil
 		})
+
+		It("allows a persistentdw request when the PSI does not yet exist", func() {
+			Expect(k8sClient.Delete(context.TODO(), psi)).To(Succeed())
+			psi = nil
+
+			Expect(k8sClient.Create(context.TODO(), workflow)).To(Succeed())
+		})
+
+		It("allows a destroy_persistent request when the PSI does not yet exist", func() {
+			workflow.Spec.DWDirectives = []string{"#DW destroy_persistent name=shared-psi"}
+			Expect(k8sClient.Delete(context.TODO(), psi)).To(Succeed())
+			psi = nil
+
+			Expect(k8sClient.Create(context.TODO(), workflow)).To(Succeed())
+		})
 	})
 })

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -59,6 +59,12 @@ rules:
 - apiGroups:
   - dataworkflowservices.github.io
   resources:
+  - persistentstorageinstances
+  verbs:
+  - get
+- apiGroups:
+  - dataworkflowservices.github.io
+  resources:
   - workflows
   verbs:
   - get

--- a/utils/dwdparse/dwdparse.go
+++ b/utils/dwdparse/dwdparse.go
@@ -242,7 +242,7 @@ func ValidateArgs(spec DWDirectiveRuleSpec, args map[string]string, uniqueMap ma
 
 // Validate a list of directives against the supplied rules. When a directive is valid
 // for a particular rule, the `onValidDirectiveFunc` function is called.
-func Validate(rules []DWDirectiveRuleSpec, directives []string, onValidDirectiveFunc func(index int, rule DWDirectiveRuleSpec)) error {
+func Validate(rules []DWDirectiveRuleSpec, directives []string, onValidDirectiveFunc func(index int, rule DWDirectiveRuleSpec) error) error {
 
 	// Create a map to track argument uniqueness within the directives for
 	// rules that contain `UniqueWithin`
@@ -262,7 +262,9 @@ func Validate(rules []DWDirectiveRuleSpec, directives []string, onValidDirective
 
 			if valid {
 				validDirective = true
-				onValidDirectiveFunc(index, rule)
+				if err := onValidDirectiveFunc(index, rule); err != nil {
+					return err
+				}
 			}
 		}
 

--- a/utils/dwdparse/dwdparse_test.go
+++ b/utils/dwdparse/dwdparse_test.go
@@ -345,7 +345,7 @@ var dwDirectiveTests = []struct {
 func TestDWParse(t *testing.T) {
 	for index, tt := range dwDirectiveTests {
 
-		err := Validate(dWDRules, tt.directiveList, func(int, DWDirectiveRuleSpec) {})
+		err := Validate(dWDRules, tt.directiveList, func(int, DWDirectiveRuleSpec) error { return nil })
 
 		if (tt.result == pass && err != nil) || (tt.result == fail && err == nil) {
 			t.Errorf("TestDWParse(%s)(%d): expect_valid(%v) err(%v)", tt.directiveList, index, tt.result, err)
@@ -362,7 +362,7 @@ type testCase struct {
 // test provides a common method to test a series of test cases against a set of rules
 func test(t *testing.T, rules []DWDirectiveRuleSpec, tests []testCase) {
 	for index, tc := range tests {
-		err := Validate(rules, tc.directives, func(int, DWDirectiveRuleSpec) {})
+		err := Validate(rules, tc.directives, func(int, DWDirectiveRuleSpec) error { return nil })
 
 		if (tc.result == pass && err != nil) || (tc.result == fail && err == nil) {
 			t.Errorf("test(%s)(%d): expected(%v) err(%v)", tc.directives, index, tc.result, err)


### PR DESCRIPTION
## Summary

This PR moves persistent storage instance (PSI) userID validation into the workflow validating webhook and introduces an annotation-based opt-out mechanism, while relaxing admission to avoid race conditions with PSI creation.

## Changes

### 1. Validate PSI UID in workflow directive webhook

- The workflow webhook now checks that the workflow's `userID` matches the referenced PSI's `userID` at admission time for `persistentdw` and `destroy_persistent` directives.
- A new annotation `dataworkflowservices.github.io/ignore-uid` on a PSI allows `persistentdw` workflows to bypass the UID check. `destroy_persistent` always enforces the check.
- Adds RBAC for the webhook to `get` PersistentStorageInstances.

### 2. Allow PSI userID to be modified

- Removes the immutability constraint on `spec.userID` in the PSI webhook, allowing operators to reassign persistent storage to different users.

### 3. Allow workflows referencing non-existent PSIs to pass admission

- Fixes a race condition where the webhook rejected workflows referencing PSIs that hadn't been created yet (e.g., `create_persistent` still reconciling).
- When the PSI is not found, the webhook now returns success and defers existence validation to the reconciler.

## Testing

All webhook integration tests pass (45 specs), including new cases for:
- UID mismatch rejection (persistentdw, destroy_persistent)
- Annotation bypass (persistentdw allowed, destroy_persistent still rejected)
- PSI not yet created (both commands allowed through)