### PR TITLE
Allow PersistentStorageInstance UserID to be modified

### DIFF
--- a/api/v1alpha7/persistentstorageinstance_webhook.go
+++ b/api/v1alpha7/persistentstorageinstance_webhook.go
@@ -85,10 +85,6 @@ func (r *PersistentStorageInstance) ValidateUpdate(old runtime.Object) (admissio
 		return nil, immutableError("DWDirective")
 	}
 
-	if r.Spec.UserID != oldPSI.Spec.UserID {
-		return nil, immutableError("UserID")
-	}
-
 	return nil, nil
 }
 

--- a/api/v1alpha7/persistentstorageinstance_webhook_test.go
+++ b/api/v1alpha7/persistentstorageinstance_webhook_test.go
@@ -88,9 +88,9 @@ var _ = Describe("PersistentStorageInstance Webhook", func() {
 			Expect(k8sClient.Update(context.TODO(), psi)).ShouldNot(Succeed())
 		})
 
-		It("should reject changes to UserID", func() {
+		It("should allow changes to UserID", func() {
 			psi.Spec.UserID = 9999
-			Expect(k8sClient.Update(context.TODO(), psi)).ShouldNot(Succeed())
+			Expect(k8sClient.Update(context.TODO(), psi)).Should(Succeed())
 		})
 
 		It("should allow transitioning State to Destroying", func() {


### PR DESCRIPTION
Remove the UserID immutability check from the PersistentStorageInstance validating webhook, allowing the PSI's UserID to be updated after creation.

This enables admins to reassign persistent storage ownership without recreating the PSI. The UID validation for workflow admission (ensuring workflow userID matches PSI userID) will be handled in nnf-sos where the check is already performed during reconciliation.